### PR TITLE
Enable per-workspace override of MSBuildExtensionsPath.

### DIFF
--- a/src/LanguageServer.Engine/Configuration.cs
+++ b/src/LanguageServer.Engine/Configuration.cs
@@ -40,6 +40,12 @@ namespace MSBuildProjectTools.LanguageServer
         /// </summary>
         [JsonProperty("language", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public LanguageConfiguration Language { get; } = new LanguageConfiguration();
+
+        /// <summary>
+        ///     The MSBuild language service's MSBuild engine configuration.
+        /// </summary>
+        [JsonProperty("msbuild", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+        public MSBuildConfiguration MSBuild { get; } = new MSBuildConfiguration();
         
         /// <summary>
         ///     The MSBuild language service's NuGet configuration.
@@ -158,6 +164,31 @@ namespace MSBuildProjectTools.LanguageServer
         /// </summary>
         [JsonProperty("completionsFromProject", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
         public HashSet<CompletionSource> CompletionsFromProject { get; } = new HashSet<CompletionSource>();
+    }
+
+    /// <summary>
+    ///     Configuration for the MSBuild engine.
+    /// </summary>
+    public class MSBuildConfiguration
+    {
+        /// <summary>
+        ///     Create a new <see cref="MSBuildConfiguration"/>.
+        /// </summary>
+        public MSBuildConfiguration()
+        {
+        }
+
+        /// <summary>
+        ///     Override the default value of MSBuildExtensionsPath.
+        /// </summary>
+        [JsonProperty("extensionsPath")]
+        public string ExtensionsPath { get; set; }
+
+        /// <summary>
+        ///     Override the default value of MSBuildExtensionsPath32.
+        /// </summary>
+        [JsonProperty("extensionsPath32")]
+        public string ExtensionsPath32 { get; set; }
     }
 
     /// <summary>

--- a/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
@@ -147,7 +147,11 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                     return true;
 
                 if (MSBuildProjectCollection == null)
-                    MSBuildProjectCollection = MSBuildHelper.CreateProjectCollection(ProjectFile.Directory.FullName);
+                {
+                    MSBuildProjectCollection = MSBuildHelper.CreateProjectCollection(ProjectFile.Directory.FullName,
+                        globalPropertyOverrides: GetMSBuildGlobalPropertyOverrides()
+                    );
+                }
 
                 if (HasMSBuildProject && IsDirty)
                 {

--- a/src/LanguageServer.Engine/Documents/ProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/ProjectDocument.cs
@@ -613,6 +613,20 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         }
 
         /// <summary>
+        ///     Get overrides (if any) for MSBuild global properties.
+        /// </summary>
+        protected virtual Dictionary<string, string> GetMSBuildGlobalPropertyOverrides()
+        {
+            var propertyOverrides = new Dictionary<string, string>();
+            if (!String.IsNullOrWhiteSpace(Workspace.Configuration.MSBuild.ExtensionsPath))
+                propertyOverrides[MSBuildHelper.WellKnownPropertyNames.MSBuildExtensionsPath] = Workspace.Configuration.MSBuild.ExtensionsPath;
+            if (!String.IsNullOrWhiteSpace(Workspace.Configuration.MSBuild.ExtensionsPath32))
+                propertyOverrides[MSBuildHelper.WellKnownPropertyNames.MSBuildExtensionsPath32] = Workspace.Configuration.MSBuild.ExtensionsPath32;
+
+            return propertyOverrides;
+        }
+
+        /// <summary>
         ///     Attempt to load the underlying MSBuild project.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
tintoy/msbuild-project-tools-vscode#35