### PR TITLE
fix toolsversion related exception when using dotnet-sdk3.

### DIFF
--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -97,7 +97,10 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                 projectCollection: projectCollection,
                 msbuildOverrideTasksPath: ""
             );
+            // using exact version of toolset
+            projectCollection.RemoveAllToolsets();
             projectCollection.AddToolset(toolset);
+            projectCollection.DefaultToolsVersion = toolsVersion;
 
             return projectCollection;
         }


### PR DESCRIPTION
related on tintoy/msbuild-project-tools-vscode#46