### PR TITLE
Update building guide to include ways to debug LSP

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,5 @@
 ﻿$dotnet = Get-Command 'dotnet'
 
+& $dotnet restore
 & $dotnet publish "$PSScriptRoot\src\LanguageServer\LanguageServer.csproj" -f net6.0 -o "$PSScriptRoot\out\language-server"
 & $dotnet publish "$PSScriptRoot\src\LanguageServer.TaskReflection\LanguageServer.TaskReflection.csproj" -f net6.0 -o "$PSScriptRoot\out\task-reflection"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo 'Restoring Nuget packages...'
+dotnet restore
+
 echo 'Building language server...'
 dotnet publish src/LanguageServer/LanguageServer.csproj -f net6.0 -o $PWD/out/language-server
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,11 +2,20 @@
 
 You'll need:
 
-1. .NET Core 2.0.0 or newer
+1. .NET 6.0.0 or newer
 
 To build:
 
-1. `dotnet restore`
-3. `dotnet publish src/LanguageServer/LanguageServer.csproj -f net6.0 -o $PWD/out/language-server`
-3. `dotnet publish src/LanguageServer.TaskReflection/LanguageServer.TaskReflection.csproj -f net6.0 -o $PWD/out/task-reflection`
+1. `powershell build.ps1`
 
+Debugging:
+
+There are 2 main ways of debugging this LSP:
+- Debugging tests: Just debug a test via your IDE, nothing special here
+- Debugging as part of VS Code extension:
+  1. Clone [extension repo](https://github.com/tintoy/msbuild-project-tools-vscode) for this LSP
+  2. Follow [the guide](https://github.com/tintoy/msbuild-project-tools-vscode/blob/master/docs/BUILDING.md) and start debugging that extension
+  3. After new VS Code window appeared, choose `Attach to LSP process` debug configuration and manually attach to LSP process, spawned by extension
+  4. Now you can trigger various LSP calls via VS Code window (the one that appeared after you started debugging extension) and hit your breakpoints in LSP code
+
+Note that in the second setup you don't work with this repo directly, but through git submodules system in extension repo


### PR DESCRIPTION
1. Added `restore` command to building scripts
2. Updated building guides to include information about various ways to debug LSP