### PR TITLE
Move to built-in System.Text.Json in TaskReflection project

### DIFF
--- a/src/LanguageServer.TaskReflection/LanguageServer.TaskReflection.csproj
+++ b/src/LanguageServer.TaskReflection/LanguageServer.TaskReflection.csproj
@@ -10,7 +10,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
         <PackageReference Include="Serilog" Version="2.5.0" />
     </ItemGroup>


### PR DESCRIPTION
As far as I know this project started before System.Text.Json was even a thing. At that time using Newtonsoft was kinda s standart for json workloads in .NET ecosystem. However, since now we target .NET 6, the built-in solution now have all capabilities that we need. Therefore I would say it is preferable to use what is given to us out of the box for several reasons:
1. This way the resulting bundle size becomes smaller
2. We don't need to control dependency updates since built-in library automatically updated when we bump target framework version
3. System.Text.Json was designed to be efficient and is considered to be one of the best json libraries form perf perspective

Closes https://github.com/tintoy/msbuild-project-tools-server/pull/30 as no longer relevant