### PR TITLE
Fix regression introduced in #36

### DIFF
--- a/src/LanguageServer.Engine/Documents/Workspace.cs
+++ b/src/LanguageServer.Engine/Documents/Workspace.cs
@@ -188,7 +188,11 @@ namespace MSBuildProjectTools.LanguageServer.Documents
             {
                 isNewProject = true;
 
-                MasterProject ??= new MasterProjectDocument(this, documentUri, Log);
+                if (MasterProject == null)
+                {
+                    MasterProject = new MasterProjectDocument(this, documentUri, Log);
+                    return MasterProject;
+                }
 
                 SubProjectDocument subProject = new SubProjectDocument(this, documentUri, Log, MasterProject);
                 MasterProject.AddSubProject(subProject);


### PR DESCRIPTION
For context, before #36 code looked like:
```cs
if (MasterProject == null)
    return MasterProject = new MasterProjectDocument(this, documentUri, Log);
```
Since 2 people looked at this code and didn't notice behavior change, let's separate assign and return statements for better readability