### PR TITLE
Move to built-in System.Text.Json API when parsing project assets file

### DIFF
--- a/src/LanguageServer.Engine/Documents/ProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/ProjectDocument.cs
@@ -295,7 +295,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
 
             IsMSBuildProjectCached = !loaded;
 
-            await UpdatePackageReferences(cancellationToken);
+            UpdatePackageReferences();
         }
 
         /// <summary>
@@ -304,13 +304,10 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         /// <param name="xml">
         ///     The project XML.
         /// </param>
-        /// <param name="cancellationToken">
-        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the operation.
-        /// </param>
         /// <returns>
         ///     A task representing the update operation.
         /// </returns>
-        public virtual async Task Update(string xml, CancellationToken cancellationToken = default)
+        public virtual void Update(string xml)
         {
             if (xml == null)
                 throw new ArgumentNullException(nameof(xml));
@@ -330,7 +327,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
 
             IsMSBuildProjectCached = !loaded;
 
-            await UpdatePackageReferences(cancellationToken);
+            UpdatePackageReferences();
         }
 
         /// <summary>
@@ -479,13 +476,10 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         /// <summary>
         ///     Re-scan referenced packages for the current project.
         /// </summary>
-        /// <param name="cancellationToken">
-        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the operation.
-        /// </param>
         /// <returns>
         ///     <c>true</c>, if the package references were successfully scanned and updated; otherwise, <c>false</c>.
         /// </returns>
-        public virtual async Task<bool> UpdatePackageReferences(CancellationToken cancellationToken = default)
+        public virtual bool UpdatePackageReferences()
         {
             try
             {
@@ -518,7 +512,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                     return false;
                 }
 
-                Dictionary<string, SemanticVersion> referencedPackageVersions = await MSBuildProject.GetReferencedPackageVersions(cancellationToken);
+                Dictionary<string, SemanticVersion> referencedPackageVersions = MSBuildProject.GetReferencedPackageVersions();
                 if (referencedPackageVersions == null)
                     return false;
 

--- a/src/LanguageServer.Engine/Documents/Workspace.cs
+++ b/src/LanguageServer.Engine/Documents/Workspace.cs
@@ -265,7 +265,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
             {
                 using (await projectDocument.Lock.WriterLockAsync())
                 {
-                    await projectDocument.Update(documentText);
+                    projectDocument.Update(documentText);
                 }
             }
             catch (Exception updateError)

--- a/test/LanguageServer.Engine.Tests/MSBuildTests.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Build.Evaluation;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -81,7 +80,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         /// </summary>
         [InlineData("Autofac", "4.6.1")]
         [Theory(DisplayName = "Get referenced package version from the current test project ")]
-        public async Task GetReferencedPackageVersion(string packageId, string expectedPackageVersion)
+        public void GetReferencedPackageVersion(string packageId, string expectedPackageVersion)
         {
             var projectFile = new FileInfo(
                 Path.Combine(TestDirectory.FullName, "..", "..", "..", "LanguageServer.Engine.Tests.csproj")
@@ -93,7 +92,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             Project project = LoadTestProject(projectFile.FullName);
             using (project.ProjectCollection)
             {
-                Dictionary<string, SemanticVersion> referencedPackageVersions = await project.GetReferencedPackageVersions();
+                Dictionary<string, SemanticVersion> referencedPackageVersions = project.GetReferencedPackageVersions();
                 Assert.NotNull(referencedPackageVersions);
                 Assert.NotEmpty(referencedPackageVersions);
 


### PR DESCRIPTION
Follow up to https://github.com/tintoy/msbuild-project-tools-server/pull/39

This doesn't allow to drop Newtonsoft dependency from `LanguageServer.Common` project, but it moves us forward. This change is even guarded with test, so I am more than sure, that no regressions here.

Also `JsonNode` doesn't have async method for parsing from stream (and it's a bit odd), so several async methods become normal now