### PR TITLE
Remove direct Nuget dependency from `SemanticModel.Xml` project

### DIFF
--- a/src/LanguageServer.SemanticModel.Xml/LanguageServer.SemanticModel.Xml.csproj
+++ b/src/LanguageServer.SemanticModel.Xml/LanguageServer.SemanticModel.Xml.csproj
@@ -7,12 +7,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
-        <PackageReference Include="NuGet.Client" Version="4.2.0" />
-        <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-        <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-        <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-        <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-        <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
         <PackageReference Include="Serilog" Version="2.5.0" />
     </ItemGroup>
 


### PR DESCRIPTION
`SemanticModel.Xml` doesn't directly depend on NuGet libraries and never mentions them in its source code. Thus it isn't a good practice to make such "hard dependency" in its project file. At least when time comes we have less places to change for library update

Closes https://github.com/tintoy/msbuild-project-tools-server/pull/45