### PR TITLE
Drop `Microsoft.Language.Xml` dependency from projects, that doesn't use it

### DIFF
--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -8,7 +8,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-        <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
         <PackageReference Include="NuGet.Client" Version="4.2.0" />
         <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
         <PackageReference Include="NuGet.Credentials" Version="6.0.0" />

--- a/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
+++ b/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
@@ -6,7 +6,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
         <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
         <PackageReference Include="NuGet.Client" Version="4.2.0" />

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildObject.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildObject.cs
@@ -1,4 +1,3 @@
-using Microsoft.Language.Xml;
 using System;
 
 namespace MSBuildProjectTools.LanguageServer.SemanticModel
@@ -12,7 +11,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         ///     Create a new <see cref="MSBuildObject"/>.
         /// </summary>
         /// <param name="xml">
-        ///     A <see cref="SyntaxNode"/> representing the item's corresponding XML.
+        ///     An <see cref="XSNode"/> representing the item's corresponding XML.
         /// </param>
         protected MSBuildObject(XSNode xml)
         {
@@ -23,7 +22,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         }
 
         /// <summary>
-        ///     A <see cref="SyntaxNode"/> representing the item's corresponding XML.
+        ///     An <see cref="XSNode"/> representing the item's corresponding XML.
         /// </summary>
         public XSNode Xml { get; }
 
@@ -89,7 +88,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         ///     The underlying MSBuild object.
         /// </param>
         /// <param name="declaringXml">
-        ///     A <see cref="SyntaxNode"/> representing the object's declaring XML.
+        ///     An <see cref="XSNode"/> representing the object's declaring XML.
         /// </param>
         protected MSBuildObject(TUnderlyingObject underlyingObject, XSNode declaringXml)
             : base(declaringXml)

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />


### PR DESCRIPTION
Continuation of dependency removal. This time focused specifically on `Microsoft.Language.Xml`. It is only used in `SemanticModel.Xml` and `Engine` projects, other projects don't need it