### PR TITLE
Simplify dependency list for `Common` project

### DIFF
--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -8,14 +8,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-        <PackageReference Include="NuGet.Client" Version="4.2.0" />
-        <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-        <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-        <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-        <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-        <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+        <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
         <PackageReference Include="Serilog" Version="2.5.0" />
-        <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- `System.Collection.Immutable` -> unused
- `NuGet.Client` -> unused
- `NuGet.PackageManagement` -> replaced with `Nuget.Protocol` since we use only its functionality
- `NuGet.Packaging` -> unused
- `NuGet.Configuration`, `NuGet.Credentials`, `Nuget.Versioning` -> these 3 are dependencies of `NuGet.Protocol`. In order to minimize amount of dependency errors, when 2 different versions of the same library are used let's consume these from `NuGet.Protocol` and don't depend on them directly

Closes https://github.com/tintoy/msbuild-project-tools-server/pull/47