### PR TITLE
Improve default values for well-known `LangVersion` property and a bit od clean up

### DIFF
--- a/help/properties.json
+++ b/help/properties.json
@@ -493,7 +493,27 @@
     },
     "LangVersion": {
         "description": "Which version of the target language (e.g. C# / VB) to use.",
-        "defaultValue": "latest"
+        "defaultValues": [
+            "default",
+            "latest",
+            "latestMajor",
+            "preview",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7.0",
+            "7.1",
+            "7.2",
+            "7.3",
+            "8.0",
+            "9.0",
+            "10.0",
+            "11.0",
+            "12.0"
+        ]
     },
     "LayoutDir": {
         "description": "Full path to a folder with package layout."

--- a/src/LanguageServer.Common/Help/PropertyHelp.cs
+++ b/src/LanguageServer.Common/Help/PropertyHelp.cs
@@ -18,11 +18,6 @@ namespace MSBuildProjectTools.LanguageServer.Help
         public string HelpLink { get; init; }
 
         /// <summary>
-        ///     The property's default value.
-        /// </summary>
-        public string DefaultValue { get; init; }
-
-        /// <summary>
         ///     The property's default values (if specified, the completion's snippet will present a drop-down list of values for the user to choose from as the property value.').
         /// </summary>
         public List<string> DefaultValues { get; init; }

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildSchemaHelp.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildSchemaHelp.cs
@@ -262,18 +262,17 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         ///     The property name.
         /// </param>
         /// <returns>
-        ///     A tuple containing the property's default value / values, or null / null if no defaults are available for it.
+        ///     A list containing the property's default values, or null if no defaults are available for it.
         /// </returns>
-        public static (string defaultValue, IReadOnlyList<string> defaultValues) DefaultsForProperty(string propertyName)
+        public static IReadOnlyList<string> DefaultsForProperty(string propertyName)
         {
             if (string.IsNullOrWhiteSpace(propertyName))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'propertyName'.", nameof(propertyName));
 
-            string helpKey = propertyName;
-            if (PropertyHelp.TryGetValue(helpKey, out PropertyHelp help))
-                return (help.DefaultValue, help.DefaultValues);
+            if (PropertyHelp.TryGetValue(propertyName, out PropertyHelp help))
+                return help.DefaultValues;
 
-            return (null, null);
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
- Imroved default values for well-known `LangVersion` property o include all currently possible values
- Removed concept of single default value since it isn't used now (`LangVersion` was the last property that actually used it) and it has the same effect as list of default values with a single value in it. So don't repeat ourselves)