### PR TITLE
Remove project dependencies from langusge server tests

### DIFF
--- a/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
+++ b/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
@@ -11,29 +11,6 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="4.6.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-        <PackageReference Include="OmniSharp.Extensions.JsonRpc" Version="0.7.9" />
-        <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.7.9" />
-        <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.7.9" />
-        <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-        <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
-        <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
-        <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
-        <PackageReference Include="NuGet.Client" Version="4.2.0" />
-        <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-        <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-        <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-        <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-        <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
-        <PackageReference Include="Serilog" Version="2.5.0" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-        <PackageReference Include="Sprache" Version="2.1.0" />
-        <PackageReference Include="System.Reactive" Version="3.1.1" />
-    </ItemGroup>
-    
-    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
         <PackageReference Include="xunit" Version="2.3.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />


### PR DESCRIPTION
Tests should never have explicit dependencies on libraries, used by an actual project. Because if they do there is a chance of dependency versions mismatch leading to false- or true-negative test outcomes

Closes https://github.com/tintoy/msbuild-project-tools-server/pull/49