### PR TITLE
Remove mentioning .NET 6 as a requirement for the end user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ An [LSP](https://github.com/Microsoft/language-server-protocol)-compatible langu
 
 For more information, see [msbuild-project-tools-vscode](https://github.com/tintoy/msbuild-project-tools-vscode).
 
-**Note**: You will need the .NET Core **runtime v6.0.0 (or SDK v6.0.100) or newer** installed to use the language service (but your projects can target any version you have installed).
-
 ## Building from source
 
 See [BUILDING.md](docs/BUILDING.md).


### PR DESCRIPTION
Server side of https://github.com/tintoy/msbuild-project-tools-vscode/pull/123