### PR TITLE
Remove unnecessary `Name` property from completion providers

### DIFF
--- a/src/LanguageServer.Engine/CompletionProviders/CommentCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/CommentCompletionProvider.cs
@@ -31,11 +31,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "XML Comments";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
@@ -26,14 +26,8 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            Log = logger.ForContext(GetType())
-                        .ForContext("CompletionProvider", Name);
+            Log = logger.ForContext(GetType());
         }
-
-        /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public abstract string Name { get; }
 
         /// <summary>
         ///     The sort priority for the provider's completion items.

--- a/src/LanguageServer.Engine/CompletionProviders/ICompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ICompletionProvider.cs
@@ -13,11 +13,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
     public interface ICompletionProvider
     {
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        string Name { get; }
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/ItemAttributeCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemAttributeCompletionProvider.cs
@@ -43,11 +43,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Item Attributes";
-
-        /// <summary>
         ///     The sort priority for the provider's completions.
         /// </summary>
         public override int Priority => 500;

--- a/src/LanguageServer.Engine/CompletionProviders/ItemElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemElementCompletionProvider.cs
@@ -32,11 +32,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Item Elements";
-
-        /// <summary>
         ///     The provider's default priority for completion items.
         /// </summary>
         public override int Priority => 1000;

--- a/src/LanguageServer.Engine/CompletionProviders/ItemGroupExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemGroupExpressionCompletionProvider.cs
@@ -33,11 +33,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "ItemGroup Expressions";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/ItemMetadataCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemMetadataCompletionProvider.cs
@@ -29,11 +29,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Item Metadata";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/ItemMetadataExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemMetadataExpressionCompletionProvider.cs
@@ -34,11 +34,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "ItemMetadata Expressions";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/PackageReferenceCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PackageReferenceCompletionProvider.cs
@@ -1,12 +1,11 @@
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using NuGet.Versioning;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using LspModels = OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace MSBuildProjectTools.LanguageServer.CompletionProviders
@@ -40,11 +39,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             : base(logger)
         {
         }
-
-        /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Package Reference Items";
 
         /// <summary>
         ///     The default sort priority for the provider's items.

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyConditionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyConditionCompletionProvider.cs
@@ -31,11 +31,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Top-level Elements";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyElementCompletionProvider.cs
@@ -33,11 +33,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Property Elements";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyExpressionCompletionProvider.cs
@@ -33,11 +33,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Property Expressions";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/TargetNameCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TargetNameCompletionProvider.cs
@@ -35,11 +35,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Target Name Attributes";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
@@ -32,11 +32,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Task Elements";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/TaskParameterCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskParameterCompletionProvider.cs
@@ -32,11 +32,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Task Attributes";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">

--- a/src/LanguageServer.Engine/CompletionProviders/TopLevelElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TopLevelElementCompletionProvider.cs
@@ -31,11 +31,6 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         }
 
         /// <summary>
-        ///     The provider display name.
-        /// </summary>
-        public override string Name => "Top-level Elements";
-
-        /// <summary>
         ///     Provide completions for the specified location.
         /// </summary>
         /// <param name="location">


### PR DESCRIPTION
It was only used to enrich context for logging. However, since logger already takes source type as context and every provider has a unique name, I consider it unnecessary. Even if we for whatever reason want to enrich logger with more type-related data, we better use something like `GetType().Name`. Since logs are used to investigate things, having a direct type name there would be better. But again, I don't think that even this thing is necessary since we provide type as context anyway.

@tintoy I would like your approval on this before merging