### PR TITLE
Add completion kind to task elements

### DIFF
--- a/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
@@ -177,6 +177,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 Label = $"<{taskName}>",
                 Detail = "Task",
                 Documentation = MSBuildSchemaHelp.ForTask(taskName),
+                Kind = CompletionItemKind.Function,
                 SortText = $"{Priority:0000}<{taskName}>",
                 TextEdit = new TextEdit
                 {


### PR DESCRIPTION
Tasks are basically "other function calls" inside a target, so it makes sence to show them as functions

Before:
![Code_qYVNiu9R9n](https://github.com/tintoy/msbuild-project-tools-server/assets/70431552/d86e00b6-5ad2-4094-a592-63365cbf716b)

After:
![Code_NbPKEamDkk](https://github.com/tintoy/msbuild-project-tools-server/assets/70431552/0b0fe283-92c3-46bb-a7e2-7bd0d583c47f)
