### PR TITLE
Refactor editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,11 @@ end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
-csharp_indent_case_contents=true
-csharp_indent_case_contents_when_block=false
 
 [*.yml]
 indent_size = 2
 
+[*.cs]
 csharp_style_throw_expression = false:none
+csharp_indent_case_contents=true
+csharp_indent_case_contents_when_block=false

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,10 +3,7 @@
 
     <PropertyGroup>
       <AssetTargetFallback>dnxcore50</AssetTargetFallback>
-
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <NoWarn>IDE0016</NoWarn>
-
       <NoPackageAnalysis>true</NoPackageAnalysis>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
1. Put all C#-related options under C# section
2. Since `IDE0016` is controlled via `csharp_style_throw_expression` option, we don't need to supress it wia MsBuild's `NoWarn` property