### PR TITLE
Remove assert target fallback

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
-      <AssetTargetFallback>dnxcore50</AssetTargetFallback>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <NoPackageAnalysis>true</NoPackageAnalysis>
     </PropertyGroup>


### PR DESCRIPTION
According to [documentation](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#assettargetfallback) `AssertTargetFallback` is required to have a [valid framework identifier](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks). `dnxcore50` isn't a valid TFI AFAICT, so having such property is pointless. However, it somehow got there, so I'm not gonna merge this untill approved