### PR TITLE
Don't extend selection when completion is triggered by typing one or more trigger characters

### DIFF
--- a/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
@@ -93,12 +93,9 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            // Replace any characters that were typed to trigger the completion.
-            if (triggerCharacters != null)
+            if (!String.IsNullOrEmpty(triggerCharacters))
             {
-                targetRange = projectDocument.XmlPositions.ExtendLeft(targetRange, byCharCount: triggerCharacters.Length);
-
-                Log.Verbose("Completion was triggered by typing one or more characters; target range will be extended by {TriggerCharacterCount} characters toward start of document (now: {TargetRange}).", triggerCharacters.Length, targetRange);
+                // NOTE: VSCode / LSP no longer require the selection to be extended when providing completions triggered by typing one or more auto-closing trigger characters, but you can still perform any other special handling here (if required).
 
                 return true;
             }

--- a/src/LanguageServer.Engine/Logging/LanguageServerSink.cs
+++ b/src/LanguageServer.Engine/Logging/LanguageServerSink.cs
@@ -85,6 +85,12 @@ namespace MSBuildProjectTools.LanguageServer.Logging
 
             StringBuilder messageBuilder = new StringBuilder();
 
+            if (_levelSwitch.MinimumLevel >= LogEventLevel.Debug)
+            {
+                if (logEvent.TryGetSourceComponent(out string sourceComponent))
+                    messageBuilder.AppendFormat("[{0}] ", sourceComponent);
+            }
+
             using (StringWriter messageWriter = new StringWriter(messageBuilder))
             {
                 logEvent.RenderMessage(messageWriter);

--- a/src/LanguageServer.Engine/Logging/SerilogLanguageServerExtensions.cs
+++ b/src/LanguageServer.Engine/Logging/SerilogLanguageServerExtensions.cs
@@ -2,15 +2,88 @@ using OmniSharp.Extensions.LanguageServer.Server;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Core;
+using Serilog.Events;
 using System;
 
 namespace MSBuildProjectTools.LanguageServer.Logging
 {
     /// <summary>
-    ///     Extension methods for configuring Serilog.
+    ///     Extension methods for configuring and using Serilog.
     /// </summary>
     public static class SerilogLanguageServerExtensions
     {
+        /// <summary>
+        ///     Attempt to retrieve the log event's source component (i.e. last segment of the "SourceContext" property value).
+        /// </summary>
+        /// <param name="logEvent">
+        ///     The <see cref="LogEvent"/>.
+        /// </param>
+        /// <param name="sourceComponent">
+        ///     Receives the last segment (separator: '.') of the <see cref="LogEvent"/>'s "SourceContext" property value, if present.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c>, if the "SourceContext" property is present; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool TryGetSourceComponent(this LogEvent logEvent, out string sourceComponent)
+        {
+            if (logEvent == null)
+                throw new ArgumentNullException(nameof(logEvent));
+
+            sourceComponent = null;
+
+            string sourceContext;
+            if (!logEvent.TryGetSourceContext(out sourceContext))
+            {
+                sourceContext = "Unknown";
+
+                return false;
+            }
+
+            int lastSeparatorIndex = sourceContext.LastIndexOf('.');
+            if (lastSeparatorIndex != -1)
+                sourceComponent = sourceContext.Substring(lastSeparatorIndex + 1);
+            else
+                sourceComponent = sourceContext;
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Attempt to retrieve the log event's "SourceContext" (if present).
+        /// </summary>
+        /// <param name="logEvent">
+        ///     The <see cref="LogEvent"/>.
+        /// </param>
+        /// <param name="sourceContext">
+        ///     Receives the <see cref="LogEvent"/>'s "SourceContext" property value, if present.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c>, if the "SourceContext" property is present; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool TryGetSourceContext(this LogEvent logEvent, out string sourceContext)
+        {
+            if (logEvent == null)
+                throw new ArgumentNullException(nameof(logEvent));
+
+            sourceContext = null;
+
+            LogEventPropertyValue rawPropertyValue;
+            if (!logEvent.Properties.TryGetValue("SourceContext", out rawPropertyValue))
+                return false;
+
+            ScalarValue scalarPropertyValue = rawPropertyValue as ScalarValue;
+            if (scalarPropertyValue == null)
+                return false;
+
+            string propertyValue = scalarPropertyValue.Value as string;
+            if (String.IsNullOrWhiteSpace(propertyValue))
+                return false;
+
+            sourceContext = propertyValue;
+
+            return true;
+        }
+
         /// <summary>
         ///     Write log events to the language server logging facility.
         /// </summary>

--- a/src/LanguageServer.SemanticModel.Xml/XmlLocationExtensions.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XmlLocationExtensions.cs
@@ -370,6 +370,26 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         }
 
         /// <summary>
+        ///     Does the location represent an element content (i.e. text or whitespace)?
+        /// </summary>
+        /// <param name="location">
+        ///     The XML location.
+        /// </param>
+        /// <param name="parentElement">
+        ///     Receives the parent (i.e. containing) element.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c>, if the location represents element content; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsElementContent(this XmlLocation location, out XSElement parentElement)
+        {
+            if (location == null)
+                throw new ArgumentNullException(nameof(location));
+
+            return location.IsElement(out parentElement) && location.IsValue();
+        }
+
+        /// <summary>
         ///     Does the location represent an element's textual content?
         /// </summary>
         /// <param name="location">

--- a/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
+++ b/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
@@ -30,6 +30,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Remove="TestFiles\SimpleProject.InsertElement.Project.xml" />
+      <None Remove="TestFiles\SimpleProject.InsertElement.PropertyGroup.xml" />
+      <None Remove="TestFiles\SimpleProject.xml" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Content Include="TestProjects\Project1.csproj">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>

--- a/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.InsertElement.Project.xml
+++ b/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.InsertElement.Project.xml
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup><
+
+</Project>

--- a/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.InsertElement.PropertyGroup.xml
+++ b/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.InsertElement.PropertyGroup.xml
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable><
+    </PropertyGroup>
+
+</Project>

--- a/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.xml
+++ b/test/LanguageServer.Engine.Tests/TestFiles/SimpleProject.xml
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This is because VS Code behaviour has changed, and it no longer correctly handles extension of selection if it has inserted an auto-closing delimiter.

tintoy/msbuild-project-tools-server#71