### PR TITLE
Bump NuGet libraries versions to avoid security warning

### DIFF
--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-        <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
+        <PackageReference Include="NuGet.Protocol" Version="6.0.5" />
         <PackageReference Include="Serilog" Version="2.5.0" />
     </ItemGroup>
 

--- a/src/LanguageServer.Engine/LanguageServer.Engine.csproj
+++ b/src/LanguageServer.Engine/LanguageServer.Engine.csproj
@@ -21,11 +21,11 @@
         <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
         <PackageReference Include="NuGet.Client" Version="4.2.0" />
-        <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-        <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-        <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-        <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-        <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+        <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
+        <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
+        <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
+        <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
+        <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
         <PackageReference Include="Serilog" Version="2.5.0" />
         <PackageReference Include="System.Reactive" Version="3.1.1" />
     </ItemGroup>

--- a/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
+++ b/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
@@ -9,11 +9,11 @@
         <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
         <PackageReference Include="NuGet.Client" Version="4.2.0" />
-        <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-        <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-        <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-        <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-        <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+        <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
+        <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
+        <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
+        <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
+        <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
         <PackageReference Include="Serilog" Version="2.5.0" />
         <PackageReference Include="Sprache" Version="2.1.0" />
         <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -20,11 +20,11 @@
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
-    <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+    <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
+    <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
+    <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Enrichers.Demystify" Version="0.1.0-dev-00016" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />


### PR DESCRIPTION
Closes: https://github.com/tintoy/msbuild-project-tools-server/pull/58
Closes: https://github.com/tintoy/msbuild-project-tools-server/pull/48
Closes: https://github.com/tintoy/msbuild-project-tools-server/pull/46
Closes: https://github.com/tintoy/msbuild-project-tools-server/pull/44