### PR TITLE
Use async Main entrypoint

### DIFF
--- a/src/LanguageServer/Program.cs
+++ b/src/LanguageServer/Program.cs
@@ -98,13 +98,6 @@ namespace MSBuildProjectTools.LanguageServer
                     return 0;
                 }
             }
-            catch (AggregateException aggregateError)
-            {
-                foreach (Exception unexpectedError in aggregateError.Flatten().InnerExceptions)
-                    Console.Error.WriteLine(unexpectedError);
-
-                return 1;
-            }
             catch (Exception unexpectedError)
             {
                 Console.Error.WriteLine(unexpectedError);


### PR DESCRIPTION
We can avoid splitting sync and async parts of `Main` method and use async `Main` directly