### PR TITLE
Improve file-access behaviour for project.assets.json

### DIFF
--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -405,7 +405,10 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             JsonNode rootNode;
             try
             {
-                rootNode = JsonNode.Parse(projectAssetsFile.OpenRead());
+                using (FileStream projectAssetsContent = projectAssetsFile.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    rootNode = JsonNode.Parse(projectAssetsContent);
+                }
             }
             catch (Exception cannotLoadProjectAssetsJson)
             {


### PR DESCRIPTION
- Ensure file stream is closed as soon as the contents have been read
- Use FileShare.Read to enable simultaneous read-access by other processes

Fixes: tintoy/msbuild-project-tools-server#82