### PR TITLE
Update MSBuild locator to the latest version

### DIFF
--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
         <PackageReference Include="NuGet.Protocol" Version="6.0.5" />
         <PackageReference Include="Serilog" Version="2.5.0" />
     </ItemGroup>

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -74,9 +74,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// </param>
         public static void DiscoverMSBuildEngine(string baseDirectory = null, ILogger logger = null)
         {
-            if (MSBuildLocator.IsRegistered)
-                MSBuildLocator.Unregister();
-
             _registeredMSBuildInstance = null;
 
             // Assume working directory is VS code's current working directory (i.e. the workspace root).

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.7.9" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.7.9" />
     <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />

--- a/test/LanguageServer.Engine.Tests/MSBuildEngineFixture.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildEngineFixture.cs
@@ -1,5 +1,3 @@
-using Microsoft.Build.Locator;
-using System;
 using Xunit;
 
 namespace MSBuildProjectTools.LanguageServer.Tests
@@ -10,7 +8,6 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     ///     An xUnit collection fixture that ensures the MSBuild Locator API is called to discover and use the latest version of the MSBuild engine before any tests are run that depend on it.
     /// </summary>
     public sealed class MSBuildEngineFixture
-        : IDisposable
     {
         /// <summary>
         ///     Create a new <see cref="MSBuildEngineFixture"/>.
@@ -18,15 +15,6 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public MSBuildEngineFixture()
         {
             MSBuildHelper.DiscoverMSBuildEngine();
-        }
-
-        /// <summary>
-        ///     Dispose of resources being used by the <see cref="MSBuildEngineFixture"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            if (MSBuildLocator.IsRegistered)
-                MSBuildLocator.Unregister();
         }
     }
 


### PR DESCRIPTION
During my investigation of https://github.com/tintoy/msbuild-project-tools-vscode/issues/89 I found out that we _need_ newer version of `MSBuild.Locator` library. I decided that it is better to separate this change in its own PR