### PR TITLE
Var preferences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,9 @@ indent_size = 2
 
 [*.cs]
 csharp_style_throw_expression = false:none
-csharp_indent_case_contents=true
-csharp_indent_case_contents_when_block=false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false

--- a/src/LanguageServer.Common/Utilities/DotNetRuntimeInfo.cs
+++ b/src/LanguageServer.Common/Utilities/DotNetRuntimeInfo.cs
@@ -261,7 +261,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            Process dotnetHostProcess = new Process
+            var dotnetHostProcess = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -285,7 +285,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                 string command = $"{dotnetHostProcess.StartInfo.FileName} {dotnetHostProcess.StartInfo.Arguments}";
 
                 // Buffer the output locally (otherwise, the process may hang if it fills up its STDOUT / STDERR buffer).
-                StringBuilder stdOutBuffer = new StringBuilder();
+                var stdOutBuffer = new StringBuilder();
                 dotnetHostProcess.OutputDataReceived += (sender, args) =>
                 {
                     lock (stdOutBuffer)
@@ -293,7 +293,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                         stdOutBuffer.AppendLine(args.Data);
                     }
                 };
-                StringBuilder stdErrBuffer = new StringBuilder();
+                var stdErrBuffer = new StringBuilder();
                 dotnetHostProcess.ErrorDataReceived += (sender, args) =>
                 {
                     lock (stdErrBuffer)
@@ -368,7 +368,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (dotnetInfoOutput == null)
                 throw new ArgumentNullException(nameof(dotnetInfoOutput));
 
-            DotNetRuntimeInfo runtimeInfo = new DotNetRuntimeInfo();
+            var runtimeInfo = new DotNetRuntimeInfo();
 
             DotnetInfoSection currentSection = DotnetInfoSection.Start;
 

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -87,14 +87,14 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             // This will also ensure that the language server's model doesn't expose any MSBuild objects anywhere.
             //
             // For now, though, let's choose the dumb option.
-            DotNetRuntimeInfo runtimeInfo = DotNetRuntimeInfo.GetCurrent(baseDirectory, logger);
+            var runtimeInfo = DotNetRuntimeInfo.GetCurrent(baseDirectory, logger);
 
             // SDK versions are in SemVer format...
             if (!SemanticVersion.TryParse(runtimeInfo.SdkVersion, out SemanticVersion targetSdkSemanticVersion))
                 throw new Exception($"Cannot determine SDK version information for current .NET SDK (located at '{runtimeInfo.BaseDirectory}').");
 
             // ...which MSBuildLocator does not understand.
-            Version targetSdkVersion = new Version(
+            var targetSdkVersion = new Version(
                 major: targetSdkSemanticVersion.Major,
                 minor: targetSdkSemanticVersion.Minor,
                 build: targetSdkSemanticVersion.Patch
@@ -175,7 +175,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             Dictionary<string, string> globalProperties = CreateGlobalMSBuildProperties(runtimeInfo, solutionDirectory, globalPropertyOverrides);
             EnsureMSBuildEnvironment(globalProperties);
 
-            ProjectCollection projectCollection = new ProjectCollection(globalProperties) { IsBuildEnabled = false };
+            var projectCollection = new ProjectCollection(globalProperties) { IsBuildEnabled = false };
 
             if (!SemanticVersion.TryParse(runtimeInfo.SdkVersion, out SemanticVersion netcoreVersion))
                 throw new FormatException($"Cannot parse .NET SDK version '{runtimeInfo.SdkVersion}' (does not appear to be a valid semantic version).");
@@ -184,7 +184,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             string toolsVersion = netcoreVersion <= NetCoreLastSdkVersionFor150Folder ? "15.0" : "Current";
 
             // Override toolset paths (for some reason these point to the main directory where the dotnet executable lives).
-            Toolset toolset = new Toolset(toolsVersion,
+            var toolset = new Toolset(toolsVersion,
                 toolsPath: runtimeInfo.BaseDirectory,
                 projectCollection: projectCollection,
                 msbuildOverrideTasksPath: ""
@@ -336,7 +336,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                 throw new ArgumentNullException(nameof(project));
 
             ProjectRootElement clonedXml = project.Xml.DeepClone();
-            Project clonedProject = new Project(clonedXml, project.GlobalProperties, project.ToolsVersion, project.ProjectCollection)
+            var clonedProject = new Project(clonedXml, project.GlobalProperties, project.ToolsVersion, project.ProjectCollection)
             {
                 FullPath = Path.ChangeExtension(project.FullPath,
                     ".cached" + Path.GetExtension(project.FullPath)

--- a/src/LanguageServer.Common/Utilities/NuGetHelper.cs
+++ b/src/LanguageServer.Common/Utilities/NuGetHelper.cs
@@ -66,13 +66,13 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (packageSources == null)
                 throw new ArgumentNullException(nameof(packageSources));
 
-            List<SourceRepository> sourceRepositories = new List<SourceRepository>();
+            var sourceRepositories = new List<SourceRepository>();
 
             List<Lazy<INuGetResourceProvider>> providers = CreateResourceProviders(providerVersions);
 
             foreach (PackageSource packageSource in packageSources)
             {
-                SourceRepository sourceRepository = new SourceRepository(packageSource, providers);
+                var sourceRepository = new SourceRepository(packageSource, providers);
 
                 sourceRepositories.Add(sourceRepository);
             }
@@ -110,7 +110,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (providers == null)
                 throw new ArgumentNullException(nameof(providers));
 
-            SourceRepository sourceRepository = new SourceRepository(packageSource, providers);
+            var sourceRepository = new SourceRepository(packageSource, providers);
 
             return sourceRepository;
         }
@@ -161,7 +161,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (packageSources == null)
                 throw new ArgumentNullException(nameof(packageSources));
 
-            List<AutoCompleteResource> autoCompleteResources = new List<AutoCompleteResource>();
+            var autoCompleteResources = new List<AutoCompleteResource>();
 
             List<SourceRepository> sourceRepositories = packageSources.CreateResourceRepositories();
             foreach (SourceRepository sourceRepository in sourceRepositories)
@@ -249,7 +249,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             IEnumerable<NuGetVersion>[] results = await Task.WhenAll(
                 autoCompleteResources.Select(async autoCompleteResource =>
                 {
-                    using (SourceCacheContext cacheContext = new SourceCacheContext())
+                    using (var cacheContext = new SourceCacheContext())
                     {
                         return await autoCompleteResource.VersionStartsWith(packageId, versionPrefix, includePrerelease, cacheContext, logger ?? NullLogger.Instance, cancellationToken);
                     }

--- a/src/LanguageServer.Common/Utilities/TextPositions.cs
+++ b/src/LanguageServer.Common/Utilities/TextPositions.cs
@@ -210,7 +210,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
 
-            List<int> lineStarts = new List<int>();
+            var lineStarts = new List<int>();
 
             int currentPosition = 0;
             int currentLineStart = 0;

--- a/src/LanguageServer.Engine/CompletionProviders/CommentCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/CommentCompletionProvider.cs
@@ -56,7 +56,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 

--- a/src/LanguageServer.Engine/CompletionProviders/ItemAttributeCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemAttributeCompletionProvider.cs
@@ -73,7 +73,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {

--- a/src/LanguageServer.Engine/CompletionProviders/ItemElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemElementCompletionProvider.cs
@@ -62,7 +62,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l} (trigger characters = {TriggerCharacters})", location, triggerCharacters);
 
@@ -129,7 +129,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         {
             LspModels.Range replaceRangeLsp = replaceRange.ToLsp();
 
-            HashSet<string> offeredItemNames = new HashSet<string>
+            var offeredItemNames = new HashSet<string>
             {
                 "PackageReference",
                 "DotNetCliToolReference"

--- a/src/LanguageServer.Engine/CompletionProviders/ItemGroupExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemGroupExpressionCompletionProvider.cs
@@ -58,7 +58,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
@@ -116,7 +116,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         {
             LspModels.Range replaceRangeLsp = replaceRange.ToLsp();
 
-            HashSet<string> offeredItemGroupNames = new HashSet<string>
+            var offeredItemGroupNames = new HashSet<string>
             {
                 "*" // Skip virtual item type representing well-known metadata.
             };

--- a/src/LanguageServer.Engine/CompletionProviders/ItemMetadataCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemMetadataCompletionProvider.cs
@@ -56,7 +56,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {
@@ -67,7 +67,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                     return null;
                 }
 
-                HashSet<string> existingMetadata = new HashSet<string>();
+                var existingMetadata = new HashSet<string>();
 
                 completions.AddRange(
                     GetAttributeCompletions(location, existingMetadata)

--- a/src/LanguageServer.Engine/CompletionProviders/ItemMetadataExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/ItemMetadataExpressionCompletionProvider.cs
@@ -59,7 +59,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
@@ -193,7 +193,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             {
                 priority += 100;
 
-                SortedSet<string> metadataNames = new SortedSet<string>(
+                var metadataNames = new SortedSet<string>(
                     projectDocument.MSBuildProject.GetItems(targetItemType)
                         .SelectMany(
                             item => item.Metadata.Select(metadata => metadata.Name)

--- a/src/LanguageServer.Engine/CompletionProviders/PackageReferenceCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PackageReferenceCompletionProvider.cs
@@ -72,7 +72,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 throw new ArgumentNullException(nameof(projectDocument));
 
             bool isIncomplete = false;
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyConditionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyConditionCompletionProvider.cs
@@ -56,7 +56,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyElementCompletionProvider.cs
@@ -58,7 +58,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
@@ -125,7 +125,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         {
             LspModels.Range replaceRangeLsp = replaceRange.ToLsp();
 
-            HashSet<string> offeredPropertyNames = new HashSet<string>();
+            var offeredPropertyNames = new HashSet<string>();
 
             // Well-known (but standard-format) properties.
 
@@ -223,7 +223,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         /// </returns>
         static string GetCompletionText(string propertyName, IReadOnlyList<string> defaultValues)
         {
-            StringBuilder completionText = new StringBuilder();
+            var completionText = new StringBuilder();
             completionText.AppendFormat("<{0}>", propertyName);
 
             bool haveValue = false;

--- a/src/LanguageServer.Engine/CompletionProviders/PropertyExpressionCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/PropertyExpressionCompletionProvider.cs
@@ -58,7 +58,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
@@ -116,7 +116,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         {
             LspModels.Range replaceRangeLsp = replaceRange.ToLsp();
 
-            HashSet<string> offeredPropertyNames = new HashSet<string>();
+            var offeredPropertyNames = new HashSet<string>();
 
             // Well-known properties.
             foreach (string wellKnownPropertyName in MSBuildSchemaHelp.WellKnownPropertyNames)

--- a/src/LanguageServer.Engine/CompletionProviders/TargetNameCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TargetNameCompletionProvider.cs
@@ -62,7 +62,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {
@@ -74,7 +74,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 }
 
                 Range targetRange = attribute.ValueRange;
-                HashSet<string> excludeTargetNames = new HashSet<string>();
+                var excludeTargetNames = new HashSet<string>();
 
                 // Handle potentially composite (i.e. "Value1;Value2;Value3") values, where it's legal to have them.
                 if (attribute.Name != "Name" && attribute.Value.IndexOf(';') != -1)
@@ -132,7 +132,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
         /// </returns>
         public IEnumerable<CompletionItem> GetCompletionItems(ProjectDocument projectDocument, Range replaceRange, HashSet<string> excludeTargetNames)
         {
-            HashSet<string> offeredTargetNames = new HashSet<string>(excludeTargetNames);
+            var offeredTargetNames = new HashSet<string>(excludeTargetNames);
             LspModels.Range replaceRangeLsp = replaceRange.ToLsp();
 
             // Well-known targets.

--- a/src/LanguageServer.Engine/CompletionProviders/TaskCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskCompletionProvider.cs
@@ -41,7 +41,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
 
             // We trust that all tasks discovered via GetMSBuildProjectTaskAssemblies are accessible in the current project.
 
-            Dictionary<string, MSBuildTaskMetadata> tasks = new Dictionary<string, MSBuildTaskMetadata>();
+            var tasks = new Dictionary<string, MSBuildTaskMetadata>();
             foreach (MSBuildTaskAssemblyMetadata assemblyMetadata in projectDocument.GetMSBuildProjectTaskAssemblies())
             {
                 foreach (MSBuildTaskMetadata task in assemblyMetadata.Tasks)

--- a/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskElementCompletionProvider.cs
@@ -71,7 +71,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 return null;
             }
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 

--- a/src/LanguageServer.Engine/CompletionProviders/TaskParameterCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TaskParameterCompletionProvider.cs
@@ -71,7 +71,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 return null;
             }
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l}", location);
 
@@ -114,7 +114,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                     );
                 }
 
-                HashSet<string> existingAttributeNames = new HashSet<string>(
+                var existingAttributeNames = new HashSet<string>(
                     taskElement.AttributeNames
                 );
                 if (replaceAttribute != null)

--- a/src/LanguageServer.Engine/CompletionProviders/TopLevelElementCompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/TopLevelElementCompletionProvider.cs
@@ -56,7 +56,7 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
             if (projectDocument == null)
                 throw new ArgumentNullException(nameof(projectDocument));
 
-            List<CompletionItem> completions = new List<CompletionItem>();
+            var completions = new List<CompletionItem>();
 
             Log.Verbose("Evaluate completions for {XmlLocation:l} (trigger characters = {TriggerCharacters})", location, triggerCharacters);
 

--- a/src/LanguageServer.Engine/ContentProviders/HoverContentProvider.cs
+++ b/src/LanguageServer.Engine/ContentProviders/HoverContentProvider.cs
@@ -56,7 +56,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (property == null)
                 throw new ArgumentNullException(nameof(property));
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Property: `{property.Name}`"
             };
@@ -71,7 +71,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 //      We'll need to build a lookup by recursively following ProjectProperty.Predecessor.
                 Position overridingDeclarationPosition = property.DeclaringXml.Location.ToNative();
 
-                StringBuilder overrideDescription = new StringBuilder();
+                var overrideDescription = new StringBuilder();
                 string declarationFile = property.DeclaringXml.Location.File;
                 if (declarationFile != property.Property.Xml.Location.File)
                 {
@@ -123,7 +123,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (unusedProperty == null)
                 throw new ArgumentNullException(nameof(unusedProperty));
 
-            List<MarkedString> content = new List<MarkedString>();
+            var content = new List<MarkedString>();
             if (unusedProperty.Element.HasParentPath(WellKnownElementPaths.DynamicPropertyGroup))
             {
                 content.Add(
@@ -195,7 +195,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 );
             }
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Item Group: `{itemGroup.OriginatingElement.ItemType}`"
             };
@@ -205,7 +205,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 content.Add(itemTypeHelp);
 
             string[] includes = itemGroup.Includes.ToArray();
-            StringBuilder itemIncludeContent = new StringBuilder();
+            var itemIncludeContent = new StringBuilder();
             itemIncludeContent.AppendLine(
                 $"Include: `{itemGroup.OriginatingElement.Include}`  "
             );
@@ -256,7 +256,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (unusedItemGroup == null)
                 throw new ArgumentNullException(nameof(unusedItemGroup));
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Unused Item Group: `{unusedItemGroup.OriginatingElement.ItemType}` (condition is false)"
             };
@@ -265,7 +265,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (itemTypeHelp != null)
                 content.Add(itemTypeHelp);
 
-            StringBuilder descriptionContent = new StringBuilder();
+            var descriptionContent = new StringBuilder();
 
             string[] includes = unusedItemGroup.Includes.ToArray();
             descriptionContent.AppendLine(
@@ -326,7 +326,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
 
             string evaluatedCondition = _projectDocument.MSBuildProject.ExpandString(condition);
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 "Condition",
                 $"Evaluated: `{evaluatedCondition}`"
@@ -372,7 +372,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (metadataName == "Include")
                 metadataName = "Identity";
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Item Metadata: `{itemGroup.Name}.{metadataName}`"
             };
@@ -388,7 +388,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 .Distinct()
                 .ToArray();
 
-            StringBuilder metadataContent = new StringBuilder();
+            var metadataContent = new StringBuilder();
             if (metadataValues.Length > 0)
             {
                 metadataContent.AppendLine("Values:");
@@ -446,7 +446,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (metadataName == "Include")
                 metadataName = "Identity";
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Unused Item Metadata: `{itemGroup.Name}.{metadataName}` (item condition is false)"
             };
@@ -462,7 +462,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 .Distinct()
                 .ToArray();
 
-            StringBuilder metadataContent = new StringBuilder();
+            var metadataContent = new StringBuilder();
             if (metadataValues.Length > 0)
             {
                 metadataContent.AppendLine("Values:");
@@ -497,7 +497,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Target: `{target.Name}`"
             };
@@ -527,12 +527,12 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (import == null)
                 throw new ArgumentNullException(nameof(import));
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 $"Import: `{import.Name}`"
             };
 
-            StringBuilder imports = new StringBuilder("Imports:");
+            var imports = new StringBuilder("Imports:");
             imports.AppendLine();
             foreach (string projectFile in import.ImportedProjectFiles)
                 imports.AppendLine($"* [{Path.GetFileName(projectFile)}]({VSCodeDocumentUri.FromFileSystemPath(projectFile)})");
@@ -572,7 +572,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             string project = unresolvedImport.Project;
             string evaluatedProject = _projectDocument.MSBuildProject.ExpandString(project);
 
-            StringBuilder descriptionContent = new StringBuilder();
+            var descriptionContent = new StringBuilder();
             descriptionContent.AppendLine(
                 $"Project: `{project}`"
             );
@@ -589,7 +589,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 $"Evaluated Condition: `{evaluatedCondition}`"
             );
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 "Unresolved Import (condition is false)",
                 descriptionContent.ToString()
@@ -620,7 +620,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (sdkImport == null)
                 throw new ArgumentNullException(nameof(sdkImport));
 
-            StringBuilder imports = new StringBuilder("Imports:");
+            var imports = new StringBuilder("Imports:");
             imports.AppendLine();
             foreach (string projectFile in sdkImport.ImportedProjectFiles)
                 imports.AppendLine($"* `{projectFile}`");
@@ -648,7 +648,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             string condition = unresolvedSdkImport.Condition;
             string evaluatedCondition = _projectDocument.MSBuildProject.ExpandString(condition);
 
-            StringBuilder descriptionContent = new StringBuilder();
+            var descriptionContent = new StringBuilder();
             descriptionContent.AppendLine(
                 $"Condition: `{condition}`"
             );
@@ -681,7 +681,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
             if (string.IsNullOrWhiteSpace(elementDescription))
                 return null;
 
-            List<MarkedString> content = new List<MarkedString>
+            var content = new List<MarkedString>
             {
                 elementDescription
             };

--- a/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
@@ -145,8 +145,8 @@ namespace MSBuildProjectTools.LanguageServer.Documents
 
                 if (HasMSBuildProject && IsDirty)
                 {
-                    using (StringReader reader = new StringReader(Xml.ToFullString()))
-                    using (XmlTextReader xmlReader = new XmlTextReader(reader))
+                    using (var reader = new StringReader(Xml.ToFullString()))
+                    using (var xmlReader = new XmlTextReader(reader))
                     {
                         MSBuildProject.Xml.ReloadFrom(xmlReader,
                             throwIfUnsavedChanges: false,

--- a/src/LanguageServer.Engine/Documents/ProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/ProjectDocument.cs
@@ -752,9 +752,9 @@ namespace MSBuildProjectTools.LanguageServer.Documents
             if (!HasMSBuildProject)
                 throw new InvalidOperationException($"MSBuild project '{ProjectFile.FullName}' is not loaded.");
 
-            DotNetRuntimeInfo currentRuntime = DotNetRuntimeInfo.GetCurrent();
+            var currentRuntime = DotNetRuntimeInfo.GetCurrent();
 
-            List<string> taskAssemblyFiles = new List<string>
+            var taskAssemblyFiles = new List<string>
             {
                 // Include "built-in" tasks.
                 Path.Combine(currentRuntime.BaseDirectory, "Microsoft.Build.Tasks.Core.dll"),
@@ -775,7 +775,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                     .Distinct(StringComparer.OrdinalIgnoreCase)
             );
 
-            List<MSBuildTaskAssemblyMetadata> metadata = new List<MSBuildTaskAssemblyMetadata>();
+            var metadata = new List<MSBuildTaskAssemblyMetadata>();
             foreach (string taskAssemblyFile in taskAssemblyFiles)
             {
                 Log.Verbose("Scanning assembly {TaskAssemblyFile} for task metadata...", taskAssemblyFile);

--- a/src/LanguageServer.Engine/Documents/SubProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/SubProjectDocument.cs
@@ -75,8 +75,8 @@ namespace MSBuildProjectTools.LanguageServer.Documents
 
                 if (HasMSBuildProject && IsDirty)
                 {
-                    using (StringReader reader = new StringReader(Xml.ToFullString()))
-                    using (XmlTextReader xmlReader = new XmlTextReader(reader))
+                    using (var reader = new StringReader(Xml.ToFullString()))
+                    using (var xmlReader = new XmlTextReader(reader))
                     {
                         MSBuildProject.Xml.ReloadFrom(xmlReader,
                             throwIfUnsavedChanges: false,

--- a/src/LanguageServer.Engine/Documents/Workspace.cs
+++ b/src/LanguageServer.Engine/Documents/Workspace.cs
@@ -177,7 +177,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                     return MasterProject;
                 }
 
-                SubProjectDocument subProject = new SubProjectDocument(this, documentUri, Log, MasterProject);
+                var subProject = new SubProjectDocument(this, documentUri, Log, MasterProject);
                 MasterProject.AddSubProject(subProject);
 
                 return subProject;

--- a/src/LanguageServer.Engine/Handlers/CompletionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/CompletionHandler.cs
@@ -132,7 +132,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
             XmlLocation location;
 
             bool isIncomplete = false;
-            List<CompletionItem> completionItems = new List<CompletionItem>();
+            var completionItems = new List<CompletionItem>();
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {
                 Position position = parameters.Position.ToNative();
@@ -159,7 +159,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 if (parameters.Context != null && parameters.Context.TriggerKind == CompletionTriggerKind.TriggerCharacter)
                     triggerCharacters = parameters.Context.TriggerCharacter;
 
-                List<Task<CompletionList>> allProviderCompletions =
+                var allProviderCompletions =
                     _completionProviders.Select(
                         provider => provider.ProvideCompletionsAsync(location, projectDocument, triggerCharacters, cancellationToken)
                     )
@@ -167,7 +167,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
 
                 while (allProviderCompletions.Count > 0)
                 {
-                    Task<CompletionList> providerCompletionTask = await Task.WhenAny(allProviderCompletions);
+                    var providerCompletionTask = await Task.WhenAny(allProviderCompletions);
                     allProviderCompletions.Remove(providerCompletionTask);
 
                     try
@@ -201,7 +201,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
             if (completionItems.Count == 0 && !isIncomplete)
                 return NoCompletions;
 
-            CompletionList completionList = new CompletionList(completionItems, isIncomplete);
+            var completionList = new CompletionList(completionItems, isIncomplete);
 
             return completionList;
         }

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -105,7 +105,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         {
             ProjectDocument projectDocument = await Workspace.GetProjectDocument(parameters.TextDocument.Uri);
 
-            List<DocumentSymbolInformation> symbols = new List<DocumentSymbolInformation>();
+            var symbols = new List<DocumentSymbolInformation>();
             using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
             {
                 // We need a valid MSBuild project with up-to-date positional information.
@@ -143,7 +143,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                         continue;
                     }
 
-                    DocumentSymbolInformation symbol = new DocumentSymbolInformation
+                    var symbol = new DocumentSymbolInformation
                     {
                         Name = msbuildObject.Name,
                         Location = new Location

--- a/src/LanguageServer.Engine/Handlers/HoverHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/HoverHandler.cs
@@ -148,7 +148,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 MSBuildObject msbuildObject;
 
                 MarkedStringContainer hoverContent = null;
-                HoverContentProvider contentProvider = new HoverContentProvider(projectDocument);
+                var contentProvider = new HoverContentProvider(projectDocument);
                 if (location.IsElement(out XSElement element))
                 {
                     msbuildObject = projectDocument.GetMSBuildObjectAtPosition(element.Start);

--- a/src/LanguageServer.Engine/Logging/LanguageServerSink.cs
+++ b/src/LanguageServer.Engine/Logging/LanguageServerSink.cs
@@ -83,9 +83,9 @@ namespace MSBuildProjectTools.LanguageServer.Logging
             if (logEvent.Level < _levelSwitch.MinimumLevel)
                 return;
 
-            StringBuilder messageBuilder = new StringBuilder();
+            var messageBuilder = new StringBuilder();
 
-            using (StringWriter messageWriter = new StringWriter(messageBuilder))
+            using (var messageWriter = new StringWriter(messageBuilder))
             {
                 logEvent.RenderMessage(messageWriter);
             }
@@ -97,7 +97,7 @@ namespace MSBuildProjectTools.LanguageServer.Logging
                 );
             }
 
-            LogMessageParams logParameters = new LogMessageParams
+            var logParameters = new LogMessageParams
             {
                 Message = messageBuilder.ToString()
             };

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildExceptionExtensions.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildExceptionExtensions.cs
@@ -25,7 +25,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (invalidProjectFileException == null)
                 throw new ArgumentNullException(nameof(invalidProjectFileException));
 
-            Position startPosition = new Position(
+            var startPosition = new Position(
                 invalidProjectFileException.LineNumber,
                 invalidProjectFileException.ColumnNumber
             );
@@ -36,7 +36,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                 return location.Node.Range;
 
             // Otherwise, fall back to using the exception's declared end position...
-            Position endPosition = new Position(
+            var endPosition = new Position(
                 invalidProjectFileException.EndLineNumber,
                 invalidProjectFileException.EndColumnNumber
             );

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildExpressions/ExpressionHelper.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildExpressions/ExpressionHelper.cs
@@ -34,7 +34,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel.MSBuildExpressions
             if (textPositions == null)
                 throw new System.ArgumentNullException(nameof(textPositions));
 
-            Dictionary<int, Position> positionCache = new Dictionary<int, Position>();
+            var positionCache = new Dictionary<int, Position>();
             void SetRange(ExpressionNode node)
             {
                 if (!positionCache.TryGetValue(node.AbsoluteStart, out Position start))

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildObjectLocator.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildObjectLocator.cs
@@ -252,7 +252,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             }
 
             // Now process item elements and their associated items.
-            HashSet<ProjectItem> usedItems = new HashSet<ProjectItem>(_project.Items);
+            var usedItems = new HashSet<ProjectItem>(_project.Items);
             foreach (ProjectItemElement itemXml in itemsByXml.Keys)
             {
                 Position itemStart = itemXml.Location.ToNative();
@@ -290,7 +290,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
         /// </remarks>
         void AddImports()
         {
-            HashSet<ProjectImportElement> resolvedImportElements = new HashSet<ProjectImportElement>();
+            var resolvedImportElements = new HashSet<ProjectImportElement>();
             var importsBySdk =
                 _project.Imports.Where(import =>
                     IsFromCurrentProject(import.ImportingElement)
@@ -313,7 +313,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                 ));
             }
 
-            HashSet<ProjectImportElement> unresolvedImportElements = new HashSet<ProjectImportElement>(_project.Xml.Imports);
+            var unresolvedImportElements = new HashSet<ProjectImportElement>(_project.Xml.Imports);
             unresolvedImportElements.ExceptWith(resolvedImportElements);
 
             foreach (ProjectImportElement importElement in unresolvedImportElements)

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildSchemaHelp.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildSchemaHelp.cs
@@ -21,7 +21,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             var currentAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var helpDirectory = Path.Combine(currentAssemblyDirectory, "help");
 
-            JsonSerializerOptions jsonOptions = new JsonSerializerOptions()
+            var jsonOptions = new JsonSerializerOptions()
             {
                 PropertyNameCaseInsensitive = true,
             };

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildTaskMetadataCache.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildTaskMetadataCache.cs
@@ -81,7 +81,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             MSBuildTaskAssemblyMetadata metadata;
             using (StateLock.Lock())
             {
-                FileInfo assemblyFile = new FileInfo(assemblyPath);
+                var assemblyFile = new FileInfo(assemblyPath);
                 if (!Assemblies.TryGetValue(assemblyPath, out metadata) || metadata.TimestampUtc < assemblyFile.LastWriteTimeUtc)
                 {
                     metadata = MSBuildTaskScanner.GetAssemblyTaskMetadata(assemblyPath, sdkBaseDirectory,
@@ -127,7 +127,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                 Assemblies.Clear();
 
                 using (StreamReader input = File.OpenText(cacheFile))
-                using (JsonTextReader json = new JsonTextReader(input))
+                using (var json = new JsonTextReader(input))
                 {
                     JsonSerializer.Create(SerializerSettings).Populate(json, this);
                 }
@@ -153,7 +153,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                     File.Delete(cacheFile);
 
                 using (StreamWriter output = File.CreateText(cacheFile))
-                using (JsonTextWriter json = new JsonTextWriter(output))
+                using (var json = new JsonTextWriter(output))
                 {
                     JsonSerializer.Create(SerializerSettings).Serialize(json, this);
                 }
@@ -179,7 +179,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (string.IsNullOrWhiteSpace(cacheFile))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'cacheFile'.", nameof(cacheFile));
 
-            MSBuildTaskMetadataCache cache = new MSBuildTaskMetadataCache(logger);
+            var cache = new MSBuildTaskMetadataCache(logger);
             cache.Load(cacheFile);
 
             return cache;

--- a/src/LanguageServer.SemanticModel.MSBuild/MSBuildTaskScanner.cs
+++ b/src/LanguageServer.SemanticModel.MSBuild/MSBuildTaskScanner.cs
@@ -115,7 +115,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
 
             string baseDirectory = Path.GetDirectoryName(taskAssemblyFile);
 
-            using MetadataLoadContext loadContext = new MetadataLoadContext(
+            using var loadContext = new MetadataLoadContext(
                 resolver: new SdkAssemblyResolver(
                     baseDirectory: Path.GetDirectoryName(taskAssemblyFile),
                     sdkBaseDirectory,

--- a/src/LanguageServer.SemanticModel.Xml/XSParser.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XSParser.cs
@@ -34,7 +34,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (xmlPositions == null)
                 throw new ArgumentNullException(nameof(xmlPositions));
 
-            XSParserVisitor parserVisitor = new XSParserVisitor(xmlPositions);
+            var parserVisitor = new XSParserVisitor(xmlPositions);
             parserVisitor.Visit(document);
             parserVisitor.FinalizeModel();
 
@@ -61,7 +61,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (xmlPositions == null)
                 throw new ArgumentNullException(nameof(xmlPositions));
 
-            XSParserVisitor parserVisitor = new XSParserVisitor(xmlPositions);
+            var parserVisitor = new XSParserVisitor(xmlPositions);
             parserVisitor.Visit(node);
             parserVisitor.FinalizeModel();
 
@@ -419,7 +419,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                 if (CurrentElement == null || !CurrentElement.Range.Contains(textRange))
                     return text;
 
-                XSElementText elementText = new XSElementText(text, textRange, CurrentElement);
+                var elementText = new XSElementText(text, textRange, CurrentElement);
                 CurrentElement.Content = CurrentElement.Content.Add(elementText);
 
                 DiscoveredNodes.Add(elementText);

--- a/src/LanguageServer.SemanticModel.Xml/XSPath.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XSPath.cs
@@ -328,14 +328,14 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (actualPathSegments.Length == 0)
                 return this;
 
-            ImmutableList<XSPathSegment> ancestorSegments = ImmutableList.CreateRange(
+            var ancestorSegments = ImmutableList.CreateRange(
                 actualPathSegments.Take(actualPathSegments.Length - 1)
             );
             ImmutableList<XSPathSegment> segments = ancestorSegments.Add(
                 actualPathSegments[^1]
             );
 
-            XSPath appendPath = new XSPath(ancestorSegments, segments);
+            var appendPath = new XSPath(ancestorSegments, segments);
             if (appendPath.IsAbsolute)
                 return appendPath;
 
@@ -476,7 +476,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
 
             XSPathSegment[] pathSegments = ParseSegments(path).ToArray();
 
-            ImmutableList<XSPathSegment> ancestorSegments = ImmutableList.CreateRange(
+            var ancestorSegments = ImmutableList.CreateRange(
                 pathSegments.Take(pathSegments.Length - 1)
             );
             ImmutableList<XSPathSegment> segments = ancestorSegments.Add(

--- a/src/LanguageServer.SemanticModel.Xml/XmlExceptionExtensions.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XmlExceptionExtensions.cs
@@ -25,7 +25,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (invalidXml == null)
                 throw new ArgumentNullException(nameof(invalidXml));
 
-            Position startPosition = new Position(
+            var startPosition = new Position(
                 invalidXml.LineNumber,
                 invalidXml.LinePosition
             );

--- a/src/LanguageServer.SemanticModel.Xml/XmlLocator.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XmlLocator.cs
@@ -103,7 +103,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             int absolutePosition = _documentPositions.GetAbsolutePosition(position);
 
             XmlLocationFlags flags = ComputeLocationFlags(nodeAtPosition, absolutePosition);
-            XmlLocation inspectionResult = new XmlLocation(position, absolutePosition, nodeAtPosition, flags);
+            var inspectionResult = new XmlLocation(position, absolutePosition, nodeAtPosition, flags);
 
             return inspectionResult;
         }
@@ -189,7 +189,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                     if (nameSpan.Contains(absolutePosition))
                         flags |= XmlLocationFlags.Name;
 
-                    TextSpan attributesSpan = new TextSpan();
+                    var attributesSpan = new TextSpan();
                     if (syntaxNode.SlashGreaterThanToken != null) // This is the most accurate way to measure the span of text where the element's attributes can be located.
                         attributesSpan = new TextSpan(start: syntaxNode.NameNode.Span.End, length: syntaxNode.SlashGreaterThanToken.Span.Start - syntaxNode.NameNode.Span.End);
                     else if (syntaxNode.AttributesNode != null)
@@ -214,7 +214,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
                     if (startTagSpan.Contains(absolutePosition))
                         flags |= XmlLocationFlags.OpeningTag;
 
-                    TextSpan attributesSpan = new TextSpan();
+                    var attributesSpan = new TextSpan();
                     if (syntaxNode.StartTag?.GreaterThanToken != null) // This is the most accurate way to measure the span of text where the element's attributes can be located.
                         attributesSpan = new TextSpan(start: syntaxNode.NameNode.Span.End, length: syntaxNode.StartTag.GreaterThanToken.Span.Start - syntaxNode.NameNode.Span.End);
                     else if (syntaxNode.AttributesNode != null)

--- a/src/LanguageServer.SemanticModel.Xml/XmlSyntaxHelper.cs
+++ b/src/LanguageServer.SemanticModel.Xml/XmlSyntaxHelper.cs
@@ -214,7 +214,7 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
             if (syntaxNode == null)
                 throw new ArgumentNullException(nameof(syntaxNode));
 
-            HashSet<SyntaxKind> kinds = new HashSet<SyntaxKind>(syntaxKinds);
+            var kinds = new HashSet<SyntaxKind>(syntaxKinds);
 
             if (kinds.Contains(syntaxNode.Kind))
                 return syntaxNode;

--- a/src/LanguageServer/Program.cs
+++ b/src/LanguageServer/Program.cs
@@ -47,7 +47,7 @@ namespace MSBuildProjectTools.LanguageServer
                 ConfigureNuGetCredentialProviders();
 
                 using (ActivityCorrelationManager.BeginActivityScope())
-                using (Terminator terminator = new Terminator())
+                using (var terminator = new Terminator())
                 using (IContainer container = BuildContainer())
                 {
                     // Force initialization of logging.
@@ -62,7 +62,7 @@ namespace MSBuildProjectTools.LanguageServer
                     Task initializeTask = server.Initialize();
 
                     // Special case for probing whether language server is startable given current runtime environment.
-                    string[] commandLineArguments = Environment.GetCommandLineArgs();
+                    var commandLineArguments = Environment.GetCommandLineArgs();
                     if (commandLineArguments.Length == 2 && commandLineArguments[1] == "--probe")
                     {
                         // Give the language server a chance to start.
@@ -137,7 +137,7 @@ namespace MSBuildProjectTools.LanguageServer
         /// </returns>
         static IContainer BuildContainer()
         {
-            ContainerBuilder builder = new ContainerBuilder();
+            var builder = new ContainerBuilder();
 
             builder.RegisterModule<LoggingModule>();
             builder.RegisterModule<LanguageServerModule>();

--- a/src/LanguageServer/Terminator.cs
+++ b/src/LanguageServer/Terminator.cs
@@ -24,7 +24,7 @@ namespace MSBuildProjectTools.LanguageServer
         /// </summary>
         static Terminator()
         {
-            using Process currentProcess = Process.GetCurrentProcess();
+            using var currentProcess = Process.GetCurrentProcess();
             CurrentProcessId = currentProcess.Id;
         }
 

--- a/test/LanguageServer.Engine.Tests/DotNetRuntimeInfoTests.cs
+++ b/test/LanguageServer.Engine.Tests/DotNetRuntimeInfoTests.cs
@@ -23,7 +23,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         {
             DotNetRuntimeInfo parsedOutput;
 
-            using (StringReader outputReader = new StringReader(dotnetInfoOutput))
+            using (var outputReader = new StringReader(dotnetInfoOutput))
             {
                 parsedOutput = DotNetRuntimeInfo.ParseDotNetInfoOutput(outputReader);
             }

--- a/test/LanguageServer.Engine.Tests/ExpressionTests/LocatorExpressionTests.cs
+++ b/test/LanguageServer.Engine.Tests/ExpressionTests/LocatorExpressionTests.cs
@@ -43,13 +43,13 @@ namespace MSBuildProjectTools.LanguageServer.Tests.ExpressionTests
         [InlineData("Test4", 5, 46, ExpressionKind.ItemMetadata)]
         public void IsExpression_Success(string testFileName, int line, int column, ExpressionKind expectedExpressionKind)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation location = locator.Inspect(testPosition);
             Assert.NotNull(location);
 

--- a/test/LanguageServer.Engine.Tests/PositionTests.cs
+++ b/test/LanguageServer.Engine.Tests/PositionTests.cs
@@ -21,7 +21,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Position.RelativeTo is correct between one-based position and origin ")]
         public void OneBased_RelativeTo_Origin(int line, int column)
         {
-            Position initialPosition = new Position(line, column);
+            var initialPosition = new Position(line, column);
 
             Position expected = initialPosition;
             Position actual = initialPosition.RelativeTo(Position.Origin);
@@ -44,7 +44,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Position.WithOrigin is correct for one-based position using origin ")]
         public void OneBased_WithOrigin_Origin(int line, int column)
         {
-            Position initialPosition = new Position(line, column);
+            var initialPosition = new Position(line, column);
 
             Position expected = initialPosition;
             Position actual = initialPosition.WithOrigin(Position.Origin);
@@ -84,10 +84,10 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Position.RelativeTo is correct for one-based positions ")]
         public void OneBased_RelativeTo_OneBased(int line, int column, int relativeToLine, int relativeToColumn, int expectedLine, int expectedColumn)
         {
-            Position initial = new Position(line, column);
-            Position relativeTo = new Position(relativeToLine, relativeToColumn);
+            var initial = new Position(line, column);
+            var relativeTo = new Position(relativeToLine, relativeToColumn);
 
-            Position expected = new Position(expectedLine, expectedColumn);
+            var expected = new Position(expectedLine, expectedColumn);
             Position actual = initial.RelativeTo(relativeTo);
             Assert.Equal(expected, actual);
             Assert.True(actual.IsOneBased, "IsOneBased");
@@ -119,10 +119,10 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Position.WithOrigin is correct for one-based positions ")]
         public void OneBased_WithOrigin_OneBased(int line, int column, int originLine, int originColumn, int expectedLine, int expectedColumn)
         {
-            Position initialPosition = new Position(line, column);
-            Position origin = new Position(originLine, originColumn);
+            var initialPosition = new Position(line, column);
+            var origin = new Position(originLine, originColumn);
 
-            Position expected = new Position(expectedLine, expectedColumn);
+            var expected = new Position(expectedLine, expectedColumn);
             Position actual = initialPosition.WithOrigin(origin);
             Assert.Equal(expected, actual);
             Assert.True(actual.IsOneBased, "IsOneBased");

--- a/test/LanguageServer.Engine.Tests/TestHelper.cs
+++ b/test/LanguageServer.Engine.Tests/TestHelper.cs
@@ -29,7 +29,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
                 throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(fileName)}.", nameof(fileName));
 
             FileInfo file = null;
-            DirectoryInfo targetDirectory = new DirectoryInfo(directory.FullName);
+            var targetDirectory = new DirectoryInfo(directory.FullName);
             while (file == null)
             {
                 file = new FileInfo(

--- a/test/LanguageServer.Engine.Tests/TextPositionsTests.cs
+++ b/test/LanguageServer.Engine.Tests/TextPositionsTests.cs
@@ -30,7 +30,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         {
             const string text = TestData.TextWithWindowsLineEndings.Text;
 
-            TextPositions textPositions = new TextPositions(text);
+            var textPositions = new TextPositions(text);
             int absolutePosition = textPositions.GetAbsolutePosition(line, column);
             Assert.Equal(expectedChar, text[absolutePosition]);
 
@@ -61,7 +61,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             int absolutePosition = text.IndexOf(forChar);
             Assert.InRange(absolutePosition, 0, text.Length - 1);
 
-            TextPositions textPositions = new TextPositions(text);
+            var textPositions = new TextPositions(text);
             Position position = textPositions.GetPosition(absolutePosition);
             Assert.True(position.IsOneBased);
             Assert.Equal(expectedLine, position.LineNumber);
@@ -90,7 +90,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         {
             const string text = TestData.TextWithUnixLineEndings.Text;
 
-            TextPositions textPositions = new TextPositions(text);
+            var textPositions = new TextPositions(text);
             int absolutePosition = textPositions.GetAbsolutePosition(line, column);
             Assert.Equal(expectedChar, text[absolutePosition]);
 
@@ -121,7 +121,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             int absolutePosition = text.IndexOf(forChar);
             Assert.InRange(absolutePosition, 0, text.Length - 1);
 
-            TextPositions textPositions = new TextPositions(text);
+            var textPositions = new TextPositions(text);
             Position position = textPositions.GetPosition(absolutePosition);
             Assert.True(position.IsOneBased);
             Assert.Equal(expectedLine, position.LineNumber);

--- a/test/LanguageServer.Engine.Tests/XSParserTests.cs
+++ b/test/LanguageServer.Engine.Tests/XSParserTests.cs
@@ -41,7 +41,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void NodeCount(string testFileName, int expectedNodeCount)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -90,7 +90,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void NodeKind(string testFileName, int index, XSNodeKind nodeKind)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -118,7 +118,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void InvalidElement(string testFileName, int index)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -169,7 +169,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void NodeRange(string testFileName, int index, int startLine, int startColumn, int endLine, int endColumn)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -185,7 +185,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
                 node.Kind
             );
 
-            Range expectedRange = new Range(
+            var expectedRange = new Range(
                 start: new Position(startLine, startColumn),
                 end: new Position(endLine, endColumn)
             );
@@ -223,7 +223,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void ElementAttributesRange(string testFileName, string elementName, int startLine, int startColumn, int endLine, int endColumn)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -234,7 +234,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
 
             XSElement targetElement = Assert.IsAssignableFrom<XSElement>(targetNode);
 
-            Range expectedRange = new Range(
+            var expectedRange = new Range(
                 start: new Position(startLine, startColumn),
                 end: new Position(endLine, endColumn)
             );
@@ -271,7 +271,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         public void InvalidElementRange(string testFileName, int nodeIndex, string elementName, int startLine, int startColumn, int endLine, int endColumn)
         {
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions xmlPositions = new TextPositions(testXml);
+            var xmlPositions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             List<XSNode> nodes = xmlDocument.GetSemanticModel(xmlPositions);
@@ -285,7 +285,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             Assert.Equal(elementName, targetElement.Name);
             Assert.False(targetElement.IsValid, "IsValid");
 
-            Range expectedRange = new Range(
+            var expectedRange = new Range(
                 start: new Position(startLine, startColumn),
                 end: new Position(endLine, endColumn)
             );

--- a/test/LanguageServer.Engine.Tests/XSPathTests.cs
+++ b/test/LanguageServer.Engine.Tests/XSPathTests.cs
@@ -27,7 +27,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath can parse absolute path ")]
         public void Can_Parse_Path_Absolute(string path, int expectedSegmentCount)
         {
-            XSPath actual = XSPath.Parse(path);
+            var actual = XSPath.Parse(path);
             Assert.NotNull(actual);
 
             Assert.True(actual.IsAbsolute, "IsAbsolute");
@@ -50,7 +50,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath can parse relative path ")]
         public void Can_Parse_Path_Relative(string path, int expectedSegmentCount)
         {
-            XSPath actual = XSPath.Parse(path);
+            var actual = XSPath.Parse(path);
             Assert.NotNull(actual);
 
             Assert.True(actual.IsRelative, "IsRelative");
@@ -74,7 +74,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath can append relative string segment ")]
         public void Can_Append_String_Segment_To_Path_Relative(string path, string segment, string expectedPath)
         {
-            XSPath actual = XSPath.Parse(path);
+            var actual = XSPath.Parse(path);
             actual += segment;
 
             Assert.Equal(expectedPath, actual.Path);
@@ -98,7 +98,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath can append relative string segment ")]
         public void Can_Append_String_Segment_To_Path_Absolute(string path, string segment, string expectedPath)
         {
-            XSPath actual = XSPath.Parse(path);
+            var actual = XSPath.Parse(path);
             actual += segment;
 
             Assert.Equal(expectedPath, actual.Path);
@@ -120,8 +120,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.StartsWith succeeds with absolute base path ")]
         public void Path_StartsWith_Absolute_Success(string path, string basePath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualBase = XSPath.Parse(basePath);
+            var actual = XSPath.Parse(path);
+            var actualBase = XSPath.Parse(basePath);
 
             Assert.True(actual.StartsWith(actualBase), "StartsWith");
         }
@@ -141,8 +141,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.EndsWith succeeds with relative base path ")]
         public void Path_EndsWith_Relative_Success(string path, string ancestorPath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualAncestor = XSPath.Parse(ancestorPath);
+            var actual = XSPath.Parse(path);
+            var actualAncestor = XSPath.Parse(ancestorPath);
 
             Assert.True(actual.EndsWith(actualAncestor), "EndsWith");
         }
@@ -164,8 +164,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.IsChildOf succeeds with absolute base path ")]
         public void Path_IsChildOf_Absolute_Success(string path, string ancestorPath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualAncestor = XSPath.Parse(ancestorPath);
+            var actual = XSPath.Parse(path);
+            var actualAncestor = XSPath.Parse(ancestorPath);
 
             Assert.True(actual.IsChildOf(actualAncestor), "IsChildOf");
         }
@@ -184,8 +184,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.IsChildOf fails with absolute base path ")]
         public void Path_IsChildOf_Absolute_Failure(string path, string ancestorPath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualAncestor = XSPath.Parse(ancestorPath);
+            var actual = XSPath.Parse(path);
+            var actualAncestor = XSPath.Parse(ancestorPath);
 
             Assert.False(actual.IsChildOf(actualAncestor), "IsChildOf");
         }
@@ -204,8 +204,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.IsChildOf succeeds with relative base path ")]
         public void Path_IsChildOf_Relative_Success(string path, string ancestorPath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualAncestor = XSPath.Parse(ancestorPath);
+            var actual = XSPath.Parse(path);
+            var actualAncestor = XSPath.Parse(ancestorPath);
 
             Assert.True(actual.IsChildOf(actualAncestor), "IsChildOf");
         }
@@ -225,8 +225,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "XSPath.IsChildOf fails with relative base path ")]
         public void Path_IsChildOf_Relative_Failure(string path, string ancestorPath)
         {
-            XSPath actual = XSPath.Parse(path);
-            XSPath actualAncestor = XSPath.Parse(ancestorPath);
+            var actual = XSPath.Parse(path);
+            var actualAncestor = XSPath.Parse(ancestorPath);
 
             Assert.False(actual.IsChildOf(actualAncestor), "IsChildOf");
         }

--- a/test/LanguageServer.Engine.Tests/XmlLocatorTests.cs
+++ b/test/LanguageServer.Engine.Tests/XmlLocatorTests.cs
@@ -40,10 +40,10 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         {
             // TODO: Change this test to use XmlLocator.
 
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax xmlDocument = Parser.ParseText(testXml);
 
             int absolutePosition = positions.GetAbsolutePosition(testPosition) - 1; // To find out if we can insert an element, make sure we find the node at the position ONE BEFORE the insertion point!
@@ -83,13 +83,13 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Within element content ")]
         public void InElementContent(string testFileName, int line, int column, XSNodeKind expectedNodeKind)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation result = locator.Inspect(testPosition);
 
             Assert.NotNull(result);
@@ -120,20 +120,20 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Within empty element's name ")]
         public void InEmptyElementName(string testFileName, int line, int column, string expectedElementName)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation result = locator.Inspect(testPosition);
 
             Assert.NotNull(result);
             Assert.Equal(XSNodeKind.Element, result.Node.Kind);
             Assert.True(result.IsElement(), "IsElement");
 
-            XSElement element = (XSElement)result.Node;
+            var element = (XSElement)result.Node;
             Assert.Equal(expectedElementName, element.Name);
 
             Assert.True(result.IsEmptyElement(), "IsEmptyElement");
@@ -169,13 +169,13 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "Within attribute's value ")]
         public void InAttributeValue(string testFileName, int line, int column, string expectedAttributeName)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation result = locator.Inspect(testPosition);
             Assert.NotNull(result);
 
@@ -208,13 +208,13 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "On element that can be replaced by completion ")]
         public void CanCompleteElement(string testFileName, int line, int column)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation location = locator.Inspect(testPosition);
             Assert.NotNull(location);
 
@@ -244,17 +244,17 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "On completable element if parent name matches ")]
         public void CanCompleteElementInParentNamed(string testFileName, int line, int column, string expectedParent)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation location = locator.Inspect(testPosition);
             Assert.NotNull(location);
 
-            XSPath expectedParentPath = XSPath.Parse(expectedParent);
+            var expectedParentPath = XSPath.Parse(expectedParent);
 
             Assert.True(
                 location.CanCompleteElement(out XSElement replaceElement, parentPath: expectedParentPath),
@@ -286,17 +286,17 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "On completable element if parent relative path matches ")]
         public void CanCompleteElementInParentWithRelativePath(string testFileName, int line, int column, string expectedParent)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation location = locator.Inspect(testPosition);
             Assert.NotNull(location);
 
-            XSPath expectedParentPath = XSPath.Parse(expectedParent);
+            var expectedParentPath = XSPath.Parse(expectedParent);
 
             Assert.True(
                 location.CanCompleteElement(out XSElement replaceElement, parentPath: expectedParentPath),
@@ -332,17 +332,17 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         [Theory(DisplayName = "On completable attribute where element name matches ")]
         public void CanCompleteAttribute(string testFileName, int line, int column, string expectedElementName, PaddingType expectedPadding)
         {
-            Position testPosition = new Position(line, column);
+            var testPosition = new Position(line, column);
 
             string testXml = LoadTestFile("TestFiles", testFileName + ".xml");
-            TextPositions positions = new TextPositions(testXml);
+            var positions = new TextPositions(testXml);
             XmlDocumentSyntax document = Parser.ParseText(testXml);
 
-            XmlLocator locator = new XmlLocator(document, positions);
+            var locator = new XmlLocator(document, positions);
             XmlLocation location = locator.Inspect(testPosition);
             Assert.NotNull(location);
 
-            XSPath elementPath = XSPath.Parse(expectedElementName);
+            var elementPath = XSPath.Parse(expectedElementName);
 
             Assert.True(
                 location.CanCompleteAttribute(out XSElement element, out XSAttribute replaceAttribute, out PaddingType needsPadding, onElementWithPath: elementPath),


### PR DESCRIPTION
"When type is apparent" case is very clear, so I enabled it as a warning to prevent it entirely. Other cases are not as clear, sometimes they improve readability, other times make unnecessary redundancy. I set the preferences, so that code fixes and refactorings can follow it, but didn't force it to the codebase