### PR TITLE
Remove obsolete/unnecessary NuGet dependencies and bump version of remaining ones

### DIFF
--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
-    <PackageReference Include="NuGet.Protocol" Version="6.0.5" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.6" />
     <PackageReference Include="Serilog" Version="2.5.0" />
   </ItemGroup>
 </Project>

--- a/src/LanguageServer.Engine/LanguageServer.Engine.csproj
+++ b/src/LanguageServer.Engine/LanguageServer.Engine.csproj
@@ -20,12 +20,7 @@
     <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
-    <PackageReference Include="NuGet.Client" Version="4.2.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
-    <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.0.6" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>

--- a/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
+++ b/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
@@ -8,12 +8,7 @@
     <PackageReference Include="Microsoft.Build" Version="16.7.0" ExcludeAssets="runtime" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
-    <PackageReference Include="NuGet.Client" Version="4.2.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
-    <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.0.6" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Sprache" Version="2.1.0" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -18,12 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="1.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
-    <PackageReference Include="NuGet.Client" Version="4.2.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.0.5" />
-    <PackageReference Include="NuGet.Credentials" Version="6.0.5" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.0.5" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.5" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.5" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.0.6" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Enrichers.Demystify" Version="0.1.0-dev-00016" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />


### PR DESCRIPTION
Closes https://github.com/tintoy/msbuild-project-tools-server/pull/97
Closes https://github.com/tintoy/msbuild-project-tools-server/pull/96
Closes https://github.com/tintoy/msbuild-project-tools-server/pull/95

- Bumped version of primary NuGet dependencies to `6.0.6` to adress dependabot alerts
- It turned out `NuGet.PackageManagement` includes all other packages as transitive dependencies, so we don't need to explicitly list them
- Removed `NuGet.Client` dependency since we don't use it and the package itself [is considered obsolete](https://www.nuget.org/packages/NuGet.Client/4.3.0-beta1-2418)