### PR TITLE
Improve handling of concurrent loads for MSBuild sub-projects

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,16 +1,18 @@
-next-version: 0.6.1
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^master$|^main$
     mode: ContinuousDelivery
-    source-branches: [ ]
+    source-branches: []
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     is-mainline: true
   feature:
     regex: ^feature(s)?\/[\d-]+
     mode: ContinuousDelivery
-    source-branches: [ 'main', 'bugfix' ]
+    source-branches:
+    - main
+    - bugfix
     tag: useBranchName
     increment: Patch
     prevent-increment-of-merged-branch-version: false
@@ -21,7 +23,8 @@ branches:
   bugfix:
     regex: ^bug(s)?\/[\d-]+|^hotfix(s)?\/[\d-]+|^fix(s)?\/[\d-]+
     mode: ContinuousDeployment
-    source-branches: [ 'main' ]
+    source-branches:
+    - main
     tag: beta
     increment: Patch
     prevent-increment-of-merged-branch-version: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,5 @@
 mode: ContinuousDeployment
+next-version: 0.6.3
 branches:
   main:
     regex: ^master$|^main$
@@ -25,7 +26,7 @@ branches:
     mode: ContinuousDeployment
     source-branches:
     - main
-    tag: beta
+    tag: useBranchName
     increment: Patch
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
@@ -33,4 +34,6 @@ branches:
     is-release-branch: false
     is-mainline: false
 ignore:
-  sha: []
+  sha:
+  - 937c06026995c95da4bb13a02714a81db87876b1
+

--- a/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/MasterProjectDocument.cs
@@ -1,6 +1,9 @@
 using Microsoft.Build.Exceptions;
+using MSBuildProjectTools.LanguageServer.SemanticModel;
+using MSBuildProjectTools.LanguageServer.Utilities;
 using Serilog;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,10 +13,6 @@ using System.Xml;
 
 namespace MSBuildProjectTools.LanguageServer.Documents
 {
-    using SemanticModel;
-    using System.Collections.Concurrent;
-    using Utilities;
-
     /// <summary>
     ///     Represents the document state for an MSBuild project.
     /// </summary>
@@ -23,7 +22,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         /// <summary>
         ///     Sub-projects (if any).
         /// </summary>
-        readonly ConcurrentDictionary<Uri, SubProjectDocument> _subProjects = new ConcurrentDictionary<Uri, SubProjectDocument>();
+        readonly ConcurrentDictionary<Uri, SubProjectDocument> _subProjects = new();
 
         /// <summary>
         ///     Create a new <see cref="MasterProjectDocument"/>.
@@ -69,7 +68,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         ///     Add a sub-project.
         /// </summary>
         /// <param name="documentUri">
-        ///     The sub-project.
+        ///     The sub-project's document URI.
         /// </param>
         /// <param name="createSubProjectDocument">
         ///     A factory delegate to create the <see cref="SubProjectDocument"/> if it does not already exist.

--- a/src/LanguageServer.Engine/Documents/Workspace.cs
+++ b/src/LanguageServer.Engine/Documents/Workspace.cs
@@ -172,7 +172,12 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                 isNewProject = true;
 
                 if (MasterProject == null)
-                    return MasterProject = new MasterProjectDocument(this, documentUri, Log);
+                {
+                    MasterProjectDocument masterProjectDocument = new(this, documentUri, Log);
+                    MasterProject = masterProjectDocument;
+
+                    return masterProjectDocument;
+                }
 
                 SubProjectDocument subProject = MasterProject.GetOrAddSubProject(documentUri,
                     () => new SubProjectDocument(this, documentUri, Log, MasterProject)

--- a/src/LanguageServer.Engine/Documents/Workspace.cs
+++ b/src/LanguageServer.Engine/Documents/Workspace.cs
@@ -172,13 +172,11 @@ namespace MSBuildProjectTools.LanguageServer.Documents
                 isNewProject = true;
 
                 if (MasterProject == null)
-                {
-                    MasterProject = new MasterProjectDocument(this, documentUri, Log);
-                    return MasterProject;
-                }
+                    return MasterProject = new MasterProjectDocument(this, documentUri, Log);
 
-                var subProject = new SubProjectDocument(this, documentUri, Log, MasterProject);
-                MasterProject.AddSubProject(subProject);
+                SubProjectDocument subProject = MasterProject.GetOrAddSubProject(documentUri,
+                    () => new SubProjectDocument(this, documentUri, Log, MasterProject)
+                );
 
                 return subProject;
             });

--- a/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
+++ b/test/LanguageServer.Engine.Tests/LanguageServer.Engine.Tests.csproj
@@ -27,16 +27,6 @@
 
   <ItemGroup>
     <Content Include="TestFiles/**/*.xml" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="TestProjects\Project1.csproj">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="TestProjects\Project1.csproj" />
+    <Content Include="TestProjects/**/*.csproj" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/test/LanguageServer.Engine.Tests/MSBuildEngineFixture.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildEngineFixture.cs
@@ -9,6 +9,8 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     /// </summary>
     public sealed class MSBuildEngineFixture
     {
+        public const string CollectionName = "MSBuild Engine";
+
         /// <summary>
         ///     Create a new <see cref="MSBuildEngineFixture"/>.
         /// </summary>
@@ -21,7 +23,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     /// <summary>
     ///     The collection-fixture binding for <see cref="MSBuildEngineFixture"/>.
     /// </summary>
-    [CollectionDefinition("MSBuild Engine")]
+    [CollectionDefinition(MSBuildEngineFixture.CollectionName)]
     public sealed class MSBuildEngineFixtureCollection
         : ICollectionFixture<MSBuildEngineFixture>
     {

--- a/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
@@ -1,8 +1,5 @@
 using Microsoft.Build.Evaluation;
-using Microsoft.Language.Xml;
 using MSBuildProjectTools.LanguageServer.SemanticModel;
-using MSBuildProjectTools.LanguageServer.Utilities;
-using Serilog;
 using System;
 using System.IO;
 using Xunit;
@@ -24,13 +21,25 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             typeof(MSBuildObjectLocatorTests).Assembly.Location
         ));
 
+        /// <summary>
+        ///     The project collection for any projects loaded by the current test.
+        /// </summary>
         ProjectCollection _projectCollection;
 
+        /// <summary>
+        ///     Create new <see cref="MSBuildObjectLocatorTests"/>.
+        /// </summary>
+        /// <param name="testOutput">
+        ///     The xUnit test output for the current test.
+        /// </param>
         public MSBuildObjectLocatorTests(ITestOutputHelper testOutput)
             : base(testOutput)
         {
         }
 
+        /// <summary>
+        ///     Dispose of resources being used by the test.
+        /// </summary>
         public void Dispose()
         {
             if (_projectCollection != null)
@@ -40,6 +49,9 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             }
         }
 
+        /// <summary>
+        ///     Verify that the <see cref="MSBuildObjectLocator"/> correctly handles a property that is defined, and then redefined, in the same project file.
+        /// </summary>
         [Fact]
         public void Can_Locate_Property_Redefined_SameFile()
         {
@@ -48,33 +60,36 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             var firstElementPosition = new Position(4, 5);                          // <Property2>false</Property2>
             var secondElementPosition = firstElementPosition.Move(lineCount: 1);    // <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
 
-            XmlLocation firstLocation = testProject.XmlLocations.Inspect(firstElementPosition);
-            MSBuildObject firstMSBuildObject = testProject.ObjectLocations.Find(firstElementPosition);
-
-            XmlLocation secondLocation = testProject.XmlLocations.Inspect(secondElementPosition);
-            MSBuildObject secondMSBuildObject = testProject.ObjectLocations.Find(secondElementPosition);
-
-            // Second "Property2" element (the overriding one).
-            //      <Property2>false</Property2>
-            XSElement secondPropertyElement;
-            Assert.True(secondLocation.IsElement(out secondPropertyElement));
-            Assert.Equal("Property2", secondPropertyElement.Name);
-
-            MSBuildProperty propertyFromSecondPosition = Assert.IsAssignableFrom<MSBuildProperty>(secondMSBuildObject);
-            Assert.Equal("Property2", propertyFromSecondPosition.Name);
-            Assert.Equal("true", propertyFromSecondPosition.Value); // property has second, overridden value
-            Assert.Equal(propertyFromSecondPosition.Element.Range, secondPropertyElement.Range); // i.e. property comes from the second Property2 element, not the first.
 
             // First "Property2" element (the overridden one).
-            //      <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
+            //      <Property2>false</Property2>
+            XmlLocation firstLocation = testProject.XmlLocations.Inspect(firstElementPosition);
+            
             XSElement firstPropertyElement;
             Assert.True(firstLocation.IsElement(out firstPropertyElement));
             Assert.Equal("Property2", firstPropertyElement.Name);
 
+            // Second "Property2" element (the overriding one).
+            //      <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
+            XmlLocation secondLocation = testProject.XmlLocations.Inspect(secondElementPosition);
+            
+            XSElement secondPropertyElement;
+            Assert.True(secondLocation.IsElement(out secondPropertyElement));
+            Assert.Equal("Property2", secondPropertyElement.Name);
+
+            // The MSBuild property "Property2" corresponding to the first "Property" element.
+            MSBuildObject firstMSBuildObject = testProject.ObjectLocations.Find(firstElementPosition);
             MSBuildProperty propertyFromFirstPosition = Assert.IsAssignableFrom<MSBuildProperty>(firstMSBuildObject);
             Assert.Equal("Property2", propertyFromFirstPosition.Name);
             Assert.Equal("true", propertyFromFirstPosition.Value); // property has second, overridden value
             Assert.Equal(propertyFromFirstPosition.Element.Range, firstPropertyElement.Range); // i.e. property comes from the second Property2 element, not the first.
+
+            // The MSBuild property "Property2" corresponding to the second "Property" element.
+            MSBuildObject secondMSBuildObject = testProject.ObjectLocations.Find(secondElementPosition);
+            MSBuildProperty propertyFromSecondPosition = Assert.IsAssignableFrom<MSBuildProperty>(secondMSBuildObject);
+            Assert.Equal("Property2", propertyFromSecondPosition.Name);
+            Assert.Equal("true", propertyFromSecondPosition.Value); // property has second, overridden value
+            Assert.Equal(propertyFromSecondPosition.Element.Range, secondPropertyElement.Range); // i.e. property comes from the second Property2 element, not the first.
         }
 
         /// <summary>
@@ -86,59 +101,16 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         /// <returns>
         ///     The loaded project, as a <see cref="TestProject"/>.
         /// </returns>
-        TestProject LoadTestProject(params string[] relativePathSegments) => TestProject.Load(ref _projectCollection, Log, relativePathSegments);
-
-        /// <summary>
-        ///     An MSBuild project, loaded for a test.
-        /// </summary>
-        /// <param name="MSBuildProject">
-        ///     The underlying MSBuild <see cref="Project"/>.
-        /// </param>
-        /// <param name="ObjectLocations">
-        ///     The <see cref="MSBuildObjectLocator"/> for the project.
-        /// </param>
-        /// <param name="XmlLocations">
-        ///     The <see cref="XmlLocator"/> for the project XML.
-        /// </param>
-        /// <param name="TextPositions">
-        ///     The <see cref="TextPositions"/> for the project text.
-        /// </param>
-        record class TestProject(Project MSBuildProject, MSBuildObjectLocator ObjectLocations, XmlLocator XmlLocations, TextPositions TextPositions)
+        TestProject LoadTestProject(params string[] relativePathSegments)
         {
-            /// <summary>
-            ///     Load a test project.
-            /// </summary>
-            /// <param name="relativePathSegments">
-            ///     The file's relative path segments.
-            /// </param>
-            /// <returns>
-            ///     The loaded project, as a <see cref="TestProject"/>.
-            /// </returns>
-            public static TestProject Load(ref ProjectCollection projectCollection, ILogger logger, params string[] relativePathSegments)
-            {
-                if (relativePathSegments == null)
-                    throw new ArgumentNullException(nameof(relativePathSegments));
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
 
-                string projectFileName = Path.Combine(
-                    TestDirectory.FullName,
-                    Path.Combine(relativePathSegments)
-                );
-                string projectDirectory = Path.GetDirectoryName(projectFileName);
-
-                if (projectCollection == null)
-                    projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
-
-                string projectFileContent = File.ReadAllText(projectFileName);
-                XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
-
-                var xmlPositions = new TextPositions(projectFileContent);
-                var xmlLocator = new XmlLocator(projectXml, xmlPositions);
-
-                Project msbuildProject = projectCollection.LoadProject(projectFileName);
-                var msbuildObjectLocator = new MSBuildObjectLocator(msbuildProject, xmlLocator, xmlPositions);
-
-                return new TestProject(msbuildProject, msbuildObjectLocator, xmlLocator, xmlPositions);
-            }
-        };
+            return TestProject.Load(
+                projectCollection: ref _projectCollection,
+                logger: Log,
+                relativePathSegments: [TestDirectory.FullName, .. relativePathSegments]
+            );
+        }
     }
 }

--- a/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.Build.Evaluation;
+using Microsoft.Language.Xml;
+using MSBuildProjectTools.LanguageServer.SemanticModel;
+using MSBuildProjectTools.LanguageServer.Utilities;
+using Serilog;
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MSBuildProjectTools.LanguageServer.Tests
+{
+    /// <summary>
+    ///     Tests for locating MSBuild objects by position.
+    /// </summary>
+    [Collection(MSBuildEngineFixture.CollectionName)]
+    public class MSBuildObjectLocatorTests
+        : TestBase, IDisposable
+    {
+        /// <summary>
+        ///     The directory for test files.
+        /// </summary>
+        static readonly DirectoryInfo TestDirectory = new DirectoryInfo(Path.GetDirectoryName(
+            typeof(MSBuildObjectLocatorTests).Assembly.Location
+        ));
+
+        ProjectCollection _projectCollection;
+
+        public MSBuildObjectLocatorTests(ITestOutputHelper testOutput)
+            : base(testOutput)
+        {
+        }
+
+        public void Dispose()
+        {
+            if (_projectCollection != null)
+            {
+                _projectCollection.Dispose();
+                _projectCollection = null;
+            }
+        }
+
+        [Fact]
+        public void Can_Locate_Property_Redefined_SameFile()
+        {
+            TestProject testProject = LoadTestProject("TestProjects", "RedefineProperty.SameFile.csproj");
+
+            var firstElementPosition = new Position(4, 5);                          // <Property2>false</Property2>
+            var secondElementPosition = firstElementPosition.Move(lineCount: 1);    // <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
+
+            XmlLocation firstLocation = testProject.XmlLocations.Inspect(firstElementPosition);
+            MSBuildObject firstMSBuildObject = testProject.ObjectLocations.Find(firstElementPosition);
+
+            XmlLocation secondLocation = testProject.XmlLocations.Inspect(secondElementPosition);
+            MSBuildObject secondMSBuildObject = testProject.ObjectLocations.Find(secondElementPosition);
+
+            // Second "Property2" element (the overriding one).
+            //      <Property2>false</Property2>
+            XSElement secondPropertyElement;
+            Assert.True(secondLocation.IsElement(out secondPropertyElement));
+            Assert.Equal("Property2", secondPropertyElement.Name);
+
+            MSBuildProperty propertyFromSecondPosition = Assert.IsAssignableFrom<MSBuildProperty>(secondMSBuildObject);
+            Assert.Equal("Property2", propertyFromSecondPosition.Name);
+            Assert.Equal("true", propertyFromSecondPosition.Value); // property has second, overridden value
+            Assert.Equal(propertyFromSecondPosition.Element.Range, secondPropertyElement.Range); // i.e. property comes from the second Property2 element, not the first.
+
+            // First "Property2" element (the overridden one).
+            //      <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
+            XSElement firstPropertyElement;
+            Assert.True(firstLocation.IsElement(out firstPropertyElement));
+            Assert.Equal("Property2", firstPropertyElement.Name);
+
+            MSBuildProperty propertyFromFirstPosition = Assert.IsAssignableFrom<MSBuildProperty>(firstMSBuildObject);
+            Assert.Equal("Property2", propertyFromFirstPosition.Name);
+            Assert.Equal("true", propertyFromFirstPosition.Value); // property has second, overridden value
+            Assert.Equal(propertyFromFirstPosition.Element.Range, firstPropertyElement.Range); // i.e. property comes from the second Property2 element, not the first.
+        }
+
+        /// <summary>
+        ///     Load a test project.
+        /// </summary>
+        /// <param name="relativePathSegments">
+        ///     The file's relative path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as a <see cref="TestProject"/>.
+        /// </returns>
+        TestProject LoadTestProject(params string[] relativePathSegments) => TestProject.Load(ref _projectCollection, Log, relativePathSegments);
+
+        /// <summary>
+        ///     An MSBuild project, loaded for a test.
+        /// </summary>
+        /// <param name="MSBuildProject">
+        ///     The underlying MSBuild <see cref="Project"/>.
+        /// </param>
+        /// <param name="ObjectLocations">
+        ///     The <see cref="MSBuildObjectLocator"/> for the project.
+        /// </param>
+        /// <param name="XmlLocations">
+        ///     The <see cref="XmlLocator"/> for the project XML.
+        /// </param>
+        /// <param name="TextPositions">
+        ///     The <see cref="TextPositions"/> for the project text.
+        /// </param>
+        record class TestProject(Project MSBuildProject, MSBuildObjectLocator ObjectLocations, XmlLocator XmlLocations, TextPositions TextPositions)
+        {
+            /// <summary>
+            ///     Load a test project.
+            /// </summary>
+            /// <param name="relativePathSegments">
+            ///     The file's relative path segments.
+            /// </param>
+            /// <returns>
+            ///     The loaded project, as a <see cref="TestProject"/>.
+            /// </returns>
+            public static TestProject Load(ref ProjectCollection projectCollection, ILogger logger, params string[] relativePathSegments)
+            {
+                if (relativePathSegments == null)
+                    throw new ArgumentNullException(nameof(relativePathSegments));
+
+                string projectFileName = Path.Combine(
+                    TestDirectory.FullName,
+                    Path.Combine(relativePathSegments)
+                );
+                string projectDirectory = Path.GetDirectoryName(projectFileName);
+
+                if (projectCollection == null)
+                    projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
+
+                string projectFileContent = File.ReadAllText(projectFileName);
+                XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
+
+                var xmlPositions = new TextPositions(projectFileContent);
+                var xmlLocator = new XmlLocator(projectXml, xmlPositions);
+
+                Project msbuildProject = projectCollection.LoadProject(projectFileName);
+                var msbuildObjectLocator = new MSBuildObjectLocator(msbuildProject, xmlLocator, xmlPositions);
+
+                return new TestProject(msbuildProject, msbuildObjectLocator, xmlLocator, xmlPositions);
+            }
+        };
+    }
+}

--- a/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
@@ -106,11 +106,10 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             if (relativePathSegments == null)
                 throw new ArgumentNullException(nameof(relativePathSegments));
 
-            return TestProject.Load(
-                projectCollection: ref _projectCollection,
-                logger: Log,
-                relativePathSegments: [TestDirectory.FullName, .. relativePathSegments]
-            );
+            if (_projectCollection == null)
+                _projectCollection = TestProjects.CreateProjectCollection<MSBuildObjectLocatorTests>(Log, relativePathSegments);
+
+            return _projectCollection.LoadTestProject<MSBuildObjectLocatorTests>(relativePathSegments);
         }
     }
 }

--- a/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
+++ b/test/LanguageServer.Engine.Tests/MSBuildObjectLocatorTests.cs
@@ -10,32 +10,17 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     /// <summary>
     ///     Tests for locating MSBuild objects by position.
     /// </summary>
+    /// <param name="testOutput">
+    ///     The xUnit test output for the current test.
+    /// </param>
     [Collection(MSBuildEngineFixture.CollectionName)]
-    public class MSBuildObjectLocatorTests
-        : TestBase, IDisposable
+    public class MSBuildObjectLocatorTests(ITestOutputHelper testOutput)
+        : TestBase(testOutput), IDisposable
     {
-        /// <summary>
-        ///     The directory for test files.
-        /// </summary>
-        static readonly DirectoryInfo TestDirectory = new DirectoryInfo(Path.GetDirectoryName(
-            typeof(MSBuildObjectLocatorTests).Assembly.Location
-        ));
-
         /// <summary>
         ///     The project collection for any projects loaded by the current test.
         /// </summary>
         ProjectCollection _projectCollection;
-
-        /// <summary>
-        ///     Create new <see cref="MSBuildObjectLocatorTests"/>.
-        /// </summary>
-        /// <param name="testOutput">
-        ///     The xUnit test output for the current test.
-        /// </param>
-        public MSBuildObjectLocatorTests(ITestOutputHelper testOutput)
-            : base(testOutput)
-        {
-        }
 
         /// <summary>
         ///     Dispose of resources being used by the test.

--- a/test/LanguageServer.Engine.Tests/TestProject.cs
+++ b/test/LanguageServer.Engine.Tests/TestProject.cs
@@ -275,10 +275,10 @@ namespace MSBuildProjectTools.LanguageServer.Tests
 
             string testDeploymentDirectory = GetTestDeploymentDirectory(testClassType);
 
-            string projectFileName = Path.Combine(
+            string projectFileName = Path.Combine([
                 testDeploymentDirectory,
-                Path.Combine(relativePathSegments)
-            );
+                .. relativePathSegments
+            ]);
             projectFileName = Path.GetFullPath(projectFileName); // Flush out any relative-path issues now, rather than when we are trying to open the file.
 
             return projectFileName;
@@ -361,7 +361,11 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     /// <param name="TextPositions">
     ///     The <see cref="TextPositions"/> for the project text.
     /// </param>
-    public record class TestProjectXml(XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions);
+    public record class TestProjectXml(
+        XmlDocumentSyntax ProjectXml,
+        XmlLocator XmlLocations,
+        TextPositions TextPositions
+    );
 
     /// <summary>
     ///     An MSBuild project, loaded for a test.
@@ -381,6 +385,12 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     /// <param name="TextPositions">
     ///     The <see cref="TextPositions"/> for the project text.
     /// </param>
-    public record class TestProject(Project MSBuildProject, MSBuildObjectLocator ObjectLocations, XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions)
+    public record class TestProject(
+        Project MSBuildProject,
+        MSBuildObjectLocator ObjectLocations,
+        XmlDocumentSyntax ProjectXml,
+        XmlLocator XmlLocations,
+        TextPositions TextPositions
+    )
         : TestProjectXml(ProjectXml, XmlLocations, TextPositions);
 }

--- a/test/LanguageServer.Engine.Tests/TestProject.cs
+++ b/test/LanguageServer.Engine.Tests/TestProject.cs
@@ -5,9 +5,364 @@ using MSBuildProjectTools.LanguageServer.Utilities;
 using Serilog;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace MSBuildProjectTools.LanguageServer.Tests
 {
+    /// <summary>
+    ///     Helper methods for loading test projects.
+    /// </summary>
+    public static class TestProjects
+    {
+        /// <summary>
+        ///     Create an MSBuild <see cref="ProjectCollection"/> using the specified project directory.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="logger">
+        ///     An optional <see cref="ILogger"/> that will receives MSBuild logs.
+        /// </param>
+        /// <param name="relativeDirectoryPathSegments">
+        ///     Path segments (if any) that will be appended to the test's deployment directory to specify the project directory.
+        /// </param>
+        /// <returns>
+        ///     The configured <see cref="ProjectCollection"/>.
+        /// </returns>
+        public static ProjectCollection CreateProjectCollection<TTestClass>(params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            return CreateProjectCollection<TTestClass>(logger: null, relativePathSegments);
+        }
+
+        /// <summary>
+        ///     Create an MSBuild <see cref="ProjectCollection"/> using the specified project directory.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="logger">
+        ///     An optional <see cref="ILogger"/> that will receives MSBuild logs.
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The target project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The configured <see cref="ProjectCollection"/>.
+        /// </returns>
+        public static ProjectCollection CreateProjectCollection<TTestClass>(ILogger logger, params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            string projectDirectory = GetProjectDirectory<TTestClass>(relativePathSegments);
+
+            ProjectCollection projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
+
+            return projectCollection;
+        }
+
+        /// <summary>
+        ///     Create an MSBuild <see cref="ProjectCollection"/> using the specified project directory.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The target project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The configured <see cref="ProjectCollection"/>.
+        /// </returns>
+        public static ProjectCollection CreateProjectCollection(Type testClassType, params string[] relativePathSegments)
+        {
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            return CreateProjectCollection(testClassType, logger: null, relativePathSegments);
+        }
+
+        /// <summary>
+        ///     Create an MSBuild <see cref="ProjectCollection"/> using the specified project directory.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="logger">
+        ///     An optional <see cref="ILogger"/> that will receives MSBuild logs.
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The target project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The configured <see cref="ProjectCollection"/>.
+        /// </returns>
+        public static ProjectCollection CreateProjectCollection(Type testClassType, ILogger logger, params string[] relativePathSegments)
+        {
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            string projectDirectory = GetProjectDirectory(testClassType, relativePathSegments);
+
+            ProjectCollection projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
+
+            return projectCollection;
+        }
+
+        /// <summary>
+        ///     Load a test project into the project collection.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as a <see cref="TestProject"/>.
+        /// </returns>
+        public static TestProject LoadTestProject<TTestClass>(this ProjectCollection projectCollection, params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            if (projectCollection == null)
+                throw new ArgumentNullException(nameof(projectCollection));
+
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            Type testClassType = typeof(TTestClass);
+
+            return projectCollection.LoadTestProject(testClassType, relativePathSegments);
+        }
+
+        /// <summary>
+        ///     Load a test project into the project collection.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as a <see cref="TestProject"/>.
+        /// </returns>
+        public static TestProject LoadTestProject(this ProjectCollection projectCollection, Type testClassType, params string[] relativePathSegments)
+        {
+            if (projectCollection == null)
+                throw new ArgumentNullException(nameof(projectCollection));
+
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = GetProjectFile(testClassType, relativePathSegments);
+
+            string projectFileContent = File.ReadAllText(projectFileName);
+            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
+
+            var xmlPositions = new TextPositions(projectFileContent);
+            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
+
+            Project msbuildProject = projectCollection.GetLoadedProjects(projectFileName).FirstOrDefault();
+            if (msbuildProject == null)
+                msbuildProject = projectCollection.LoadProject(projectFileName);
+
+            var msbuildObjectLocator = new MSBuildObjectLocator(msbuildProject, xmlLocator, xmlPositions);
+
+            return new TestProject(msbuildProject, msbuildObjectLocator, projectXml, xmlLocator, xmlPositions);
+        }
+
+        /// <summary>
+        ///     Load a test project's XML.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as <see cref="TestProjectXml"/>.
+        /// </returns>
+        public static TestProjectXml LoadXml<TTestClass>(params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            Type testClassType = typeof(TTestClass);
+
+            return LoadXml(testClassType, relativePathSegments);
+        }
+
+        /// <summary>
+        ///     Load a test project's XML.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as <see cref="TestProjectXml"/>.
+        /// </returns>
+        public static TestProjectXml LoadXml(Type testClassType, params string[] relativePathSegments)
+        {
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = GetProjectFile(testClassType, relativePathSegments);
+
+            string projectFileContent = File.ReadAllText(projectFileName);
+            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
+
+            var xmlPositions = new TextPositions(projectFileContent);
+            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
+
+            return new TestProjectXml(projectXml, xmlLocator, xmlPositions);
+        }
+
+        /// <summary>
+        ///     Get the fully-qualified path of a test project file.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The full path to the project file.
+        /// </returns>
+        public static string GetProjectFile<TTestClass>(params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            Type testClassType = typeof(TTestClass);
+
+            return GetProjectFile(testClassType, relativePathSegments);
+        }
+
+        /// <summary>
+        ///     Get the fully-qualified path of a test project file.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The full path to the project file.
+        /// </returns>
+        public static string GetProjectFile(Type testClassType, params string[] relativePathSegments)
+        {
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string testDeploymentDirectory = GetTestDeploymentDirectory(testClassType);
+
+            string projectFileName = Path.Combine(
+                testDeploymentDirectory,
+                Path.Combine(relativePathSegments)
+            );
+            projectFileName = Path.GetFullPath(projectFileName); // Flush out any relative-path issues now, rather than when we are trying to open the file.
+
+            return projectFileName;
+        }
+
+        /// <summary>
+        ///     Get the fully-qualified path of a test project file.
+        /// </summary>
+        /// <typeparam name="TTestClass">
+        ///     The test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </typeparam>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The full path to the project file.
+        /// </returns>
+        public static string GetProjectDirectory<TTestClass>(params string[] relativePathSegments)
+            where TTestClass : class
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = GetProjectFile<TTestClass>(relativePathSegments);
+
+            return Path.GetDirectoryName(projectFileName);
+        }
+
+        /// <summary>
+        ///     Get the fully-qualified path of a test project file.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The type of test-suite class used to determine the assembly containing the currently-running test (which can be used to find the test's deployment directory).
+        /// </param>
+        /// <param name="relativePathSegments">
+        ///     The project file's relative (to the test deployment directory) path segments.
+        /// </param>
+        /// <returns>
+        ///     The full path to the project file.
+        /// </returns>
+        public static string GetProjectDirectory(Type testClassType, params string[] relativePathSegments)
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = GetProjectFile(testClassType, relativePathSegments);
+
+            return Path.GetDirectoryName(projectFileName);
+        }
+
+        /// <summary>
+        ///     Get the deployment directory for the specified test class.
+        /// </summary>
+        /// <param name="testClassType">
+        ///     The test class <see cref="Type"/>.
+        /// </param>
+        /// <returns>
+        ///     The test deployment directory.
+        /// </returns>
+        static string GetTestDeploymentDirectory(Type testClassType)
+        {
+            if (testClassType == null)
+                throw new ArgumentNullException(nameof(testClassType));
+
+            string testAssemblyFile = testClassType.Assembly.Location;
+            
+            return Path.GetDirectoryName(testAssemblyFile);
+        }
+    }
+
+    /// <summary>
+    ///     An MSBuild project, loaded for a test.
+    /// </summary>
+    /// <param name="ProjectXml">
+    ///     An <see cref="XmlDocumentSyntax"/> containing the project XML.
+    /// </param>
+    /// <param name="XmlLocations">
+    ///     The <see cref="XmlLocator"/> for the project XML.
+    /// </param>
+    /// <param name="TextPositions">
+    ///     The <see cref="TextPositions"/> for the project text.
+    /// </param>
+    public record class TestProjectXml(XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions);
+
     /// <summary>
     ///     An MSBuild project, loaded for a test.
     /// </summary>
@@ -27,77 +382,5 @@ namespace MSBuildProjectTools.LanguageServer.Tests
     ///     The <see cref="TextPositions"/> for the project text.
     /// </param>
     public record class TestProject(Project MSBuildProject, MSBuildObjectLocator ObjectLocations, XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions)
-        : TestProjectXml(ProjectXml, XmlLocations, TextPositions)
-    {
-        /// <summary>
-        ///     Load a test project.
-        /// </summary>
-        /// <param name="relativePathSegments">
-        ///     The file's relative path segments.
-        /// </param>
-        /// <returns>
-        ///     The loaded project, as a <see cref="TestProject"/>.
-        /// </returns>
-        public static TestProject Load(ref ProjectCollection projectCollection, ILogger logger, params string[] relativePathSegments)
-        {
-            if (relativePathSegments == null)
-                throw new ArgumentNullException(nameof(relativePathSegments));
-
-            string projectFileName = Path.Combine(relativePathSegments);
-            string projectDirectory = Path.GetDirectoryName(projectFileName);
-
-            if (projectCollection == null)
-                projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
-
-            string projectFileContent = File.ReadAllText(projectFileName);
-            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
-
-            var xmlPositions = new TextPositions(projectFileContent);
-            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
-
-            Project msbuildProject = projectCollection.LoadProject(projectFileName);
-            var msbuildObjectLocator = new MSBuildObjectLocator(msbuildProject, xmlLocator, xmlPositions);
-
-            return new TestProject(msbuildProject, msbuildObjectLocator, projectXml, xmlLocator, xmlPositions);
-        }
-
-        /// <summary>
-        ///     Load a test project's XML.
-        /// </summary>
-        /// <param name="relativePathSegments">
-        ///     The file's relative path segments.
-        /// </param>
-        /// <returns>
-        ///     The loaded project, as <see cref="TestProjectXml"/>.
-        /// </returns>
-        public static TestProjectXml LoadXml(params string[] relativePathSegments)
-        {
-            if (relativePathSegments == null)
-                throw new ArgumentNullException(nameof(relativePathSegments));
-
-            string projectFileName = Path.Combine(relativePathSegments);
-
-            string projectFileContent = File.ReadAllText(projectFileName);
-            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
-
-            var xmlPositions = new TextPositions(projectFileContent);
-            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
-
-            return new TestProjectXml(projectXml, xmlLocator, xmlPositions);
-        }
-    };
-
-    /// <summary>
-    ///     An MSBuild project, loaded for a test.
-    /// </summary>
-    /// <param name="ProjectXml">
-    ///     An <see cref="XmlDocumentSyntax"/> containing the project XML.
-    /// </param>
-    /// <param name="XmlLocations">
-    ///     The <see cref="XmlLocator"/> for the project XML.
-    /// </param>
-    /// <param name="TextPositions">
-    ///     The <see cref="TextPositions"/> for the project text.
-    /// </param>
-    public record class TestProjectXml(XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions);
+        : TestProjectXml(ProjectXml, XmlLocations, TextPositions);
 }

--- a/test/LanguageServer.Engine.Tests/TestProject.cs
+++ b/test/LanguageServer.Engine.Tests/TestProject.cs
@@ -1,0 +1,103 @@
+using Microsoft.Build.Evaluation;
+using Microsoft.Language.Xml;
+using MSBuildProjectTools.LanguageServer.SemanticModel;
+using MSBuildProjectTools.LanguageServer.Utilities;
+using Serilog;
+using System;
+using System.IO;
+
+namespace MSBuildProjectTools.LanguageServer.Tests
+{
+    /// <summary>
+    ///     An MSBuild project, loaded for a test.
+    /// </summary>
+    /// <param name="MSBuildProject">
+    ///     The underlying MSBuild <see cref="Project"/>.
+    /// </param>
+    /// <param name="ObjectLocations">
+    ///     The <see cref="MSBuildObjectLocator"/> for the project.
+    /// </param>
+    /// <param name="ProjectXml">
+    ///     An <see cref="XmlDocumentSyntax"/> containing the project XML.
+    /// </param>
+    /// <param name="XmlLocations">
+    ///     The <see cref="XmlLocator"/> for the project XML.
+    /// </param>
+    /// <param name="TextPositions">
+    ///     The <see cref="TextPositions"/> for the project text.
+    /// </param>
+    public record class TestProject(Project MSBuildProject, MSBuildObjectLocator ObjectLocations, XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions)
+        : TestProjectXml(ProjectXml, XmlLocations, TextPositions)
+    {
+        /// <summary>
+        ///     Load a test project.
+        /// </summary>
+        /// <param name="relativePathSegments">
+        ///     The file's relative path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as a <see cref="TestProject"/>.
+        /// </returns>
+        public static TestProject Load(ref ProjectCollection projectCollection, ILogger logger, params string[] relativePathSegments)
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = Path.Combine(relativePathSegments);
+            string projectDirectory = Path.GetDirectoryName(projectFileName);
+
+            if (projectCollection == null)
+                projectCollection = MSBuildHelper.CreateProjectCollection(projectDirectory, logger: logger);
+
+            string projectFileContent = File.ReadAllText(projectFileName);
+            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
+
+            var xmlPositions = new TextPositions(projectFileContent);
+            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
+
+            Project msbuildProject = projectCollection.LoadProject(projectFileName);
+            var msbuildObjectLocator = new MSBuildObjectLocator(msbuildProject, xmlLocator, xmlPositions);
+
+            return new TestProject(msbuildProject, msbuildObjectLocator, projectXml, xmlLocator, xmlPositions);
+        }
+
+        /// <summary>
+        ///     Load a test project's XML.
+        /// </summary>
+        /// <param name="relativePathSegments">
+        ///     The file's relative path segments.
+        /// </param>
+        /// <returns>
+        ///     The loaded project, as <see cref="TestProjectXml"/>.
+        /// </returns>
+        public static TestProjectXml LoadXml(params string[] relativePathSegments)
+        {
+            if (relativePathSegments == null)
+                throw new ArgumentNullException(nameof(relativePathSegments));
+
+            string projectFileName = Path.Combine(relativePathSegments);
+
+            string projectFileContent = File.ReadAllText(projectFileName);
+            XmlDocumentSyntax projectXml = Parser.ParseText(projectFileContent);
+
+            var xmlPositions = new TextPositions(projectFileContent);
+            var xmlLocator = new XmlLocator(projectXml, xmlPositions);
+
+            return new TestProjectXml(projectXml, xmlLocator, xmlPositions);
+        }
+    };
+
+    /// <summary>
+    ///     An MSBuild project, loaded for a test.
+    /// </summary>
+    /// <param name="ProjectXml">
+    ///     An <see cref="XmlDocumentSyntax"/> containing the project XML.
+    /// </param>
+    /// <param name="XmlLocations">
+    ///     The <see cref="XmlLocator"/> for the project XML.
+    /// </param>
+    /// <param name="TextPositions">
+    ///     The <see cref="TextPositions"/> for the project text.
+    /// </param>
+    public record class TestProjectXml(XmlDocumentSyntax ProjectXml, XmlLocator XmlLocations, TextPositions TextPositions);
+}

--- a/test/LanguageServer.Engine.Tests/TestProjects/RedefineProperty.SameFile.csproj
+++ b/test/LanguageServer.Engine.Tests/TestProjects/RedefineProperty.SameFile.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Property1>true</Property1>
+    <Property2>false</Property2>
+    <Property2 Condition=" '$(Property1)' == 'true' ">true</Property2>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Relates to #100, but it turns out the actual issue is related to concurrent loads of sub-projects, not overridden properties.