### PR TITLE
Validate dotnet process exit code when discovering .NET SDK / runtime info

### DIFF
--- a/src/LanguageServer.Common/Utilities/DotNetRuntimeInfo.cs
+++ b/src/LanguageServer.Common/Utilities/DotNetRuntimeInfo.cs
@@ -75,19 +75,19 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             if (Environment.GetEnvironmentVariable("MSBUILD_PROJECT_TOOLS_DOTNET_HOST_DIAGNOSTICS") == "1")
                 enableDotnetHostDiagnostics = true;
 
-            int dotNetExitCode;
+            DotNetHostExitCode dotNetExitCode;
             TextReader dotnetOutput;
 
             (dotNetExitCode, dotnetOutput) = InvokeDotNetHost("--version", baseDirectory, logger, enableHostTracing: enableDotnetHostDiagnostics);
             using (dotnetOutput)
             {
-                if (dotNetExitCode == DotNetExitCodes.CannotResolveTargetSdkOrRuntime)
+                if (dotNetExitCode == DotNetHostExitCode.LibHostSdkFindFailure)
                 {
                     logger.Error("Cannot resolve the target .NET SDK tooling or runtime. Please verify that the SDK version referenced in global.json (or a compatible runtime that matches the configured roll-forward policy) is correctly installed.");
 
                     throw new Exception("Cannot resolve the target .NET SDK tooling or runtime. Please verify that the SDK version referenced in global.json (or a compatible runtime that matches the configured roll-forward policy) is correctly installed.");
                 }
-                else if (dotNetExitCode != DotNetExitCodes.Success)
+                else if (dotNetExitCode != DotNetHostExitCode.Success)
                     throw new Exception("Failed to determine current .NET version.");
 
                 sdkVersion = ParseDotNetVersionOutput(dotnetOutput);
@@ -100,7 +100,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             (dotNetExitCode, dotnetOutput) = InvokeDotNetHost("--list-sdks", baseDirectory, logger);
             using (dotnetOutput)
             {
-                if (dotNetExitCode != DotNetExitCodes.Success)
+                if (dotNetExitCode != DotNetHostExitCode.Success)
                     throw new Exception("Failed to discover available .NET SDKs.");
 
                 List<DotnetSdkInfo> discoveredSdks = ParseDotNetListSdksOutput(dotnetOutput);
@@ -117,7 +117,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             (dotNetExitCode, dotnetOutput) = InvokeDotNetHost("--list-runtimes", baseDirectory, logger);
             using (dotnetOutput)
             {
-                if (dotNetExitCode != DotNetExitCodes.Success)
+                if (dotNetExitCode != DotNetHostExitCode.Success)
                     throw new Exception("Failed to discover available .NET runtimes.");
 
                 List<DotnetRuntimeInfo> discoveredRuntimes = ParseDotNetListRuntimesOutput(dotnetOutput);
@@ -257,7 +257,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <returns>
         ///     The process exit code, and a <see cref="TextReader"/> containing the program output (STDOUT and STDERR).
         /// </returns>
-        static (int ExitCode, TextReader StdOut) InvokeDotNetHost(string commandLineArguments, string baseDirectory, ILogger logger, bool enableHostTracing = false)
+        static (DotNetHostExitCode ExitCode, TextReader StdOut) InvokeDotNetHost(string commandLineArguments, string baseDirectory, ILogger logger, bool enableHostTracing = false)
         {
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
@@ -325,7 +325,9 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                 logger.Debug("Waiting for redirected STDOUT/STDERR streams to complete for process {TargetProcessId}...", dotnetHostProcess.Id);
                 dotnetHostProcess.WaitForExit();
 
-                logger.Debug("{Command} terminated with exit code {ExitCode}.", command, dotnetHostProcess.ExitCode);
+                var hostExitCode = (DotNetHostExitCode)dotnetHostProcess.ExitCode;
+
+                logger.Debug("{Command} terminated with exit code {ExitCode:X} ({ExitCodeName}).", command, (int)hostExitCode, hostExitCode);
 
                 string stdOut;
                 lock (stdOutBuffer)
@@ -352,7 +354,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                 }
 
                 return (
-                    ExitCode: dotnetHostProcess.ExitCode,
+                    ExitCode: hostExitCode,
                     StdOut: new StringReader(stdOut)
                 );
             }
@@ -417,16 +419,340 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
     /// <summary>
     ///     Well-known process exit codes for the "dotnet" executable.
     /// </summary>
-    public static class DotNetExitCodes
+    /// <remarks>
+    ///     <seealso href="https://github.com/dotnet/runtime/blob/d123560a23078989f9563b83fa49a24802e88378/docs/design/features/host-error-codes.md"/>
+    /// </remarks>
+    public enum DotNetHostExitCode
+        : int
     {
         /// <summary>
-        ///     The dotnet host exit code indicating that the requested operation was successful.
+        ///     Operation was successful.
         /// </summary>
-        public static readonly int Success = 0;
+        Success = 0,
 
         /// <summary>
-        ///     The dotnet host exit code indicating that the target SDK or runtime version cannot be resolved.
+        ///     Initialization was successful, but another host context is already initialized, so the returned context is "secondary" (the requested context was otherwise fully compatible with the already initialized context).
         /// </summary>
-        public static readonly int CannotResolveTargetSdkOrRuntime = -2147450735;
+        /// <remarks>
+        ///     Probably not used as an actual exit code; returned by <c>hostfxr_initialize_for_runtime_config</c> if it's called when the host is already initialized in the process.
+        /// </remarks>
+        Success_HostAlreadyInitialized = 0x00000001,
+
+        /// <summary>
+        ///     Initialization was successful, but another host context is already initialized and the requested context specified some runtime properties which are not the same (either in value or in presence) to the already initialized context.
+        /// </summary>
+        /// <remarks>
+        ///     Probably not used as an actual exit code; returned by <c>hostfxr_initialize_for_runtime_config</c> if it's called when the host is already initialized in the process.
+        /// </remarks>
+        Success_DifferentRuntimeProperties = 0x00000002,
+
+        /// <summary>
+        ///     One of the specified arguments for the operation is invalid.
+        /// </summary>
+        InvalidArgFailure = unchecked((int)0x80008081),
+
+        /// <summary>
+        ///     There was a failure loading a dependent library.
+        /// </summary>
+        /// <remarks>
+        ///     If any of the hosting components calls <c>LoadLibrary</c>/<c>dlopen</c> on a dependent library and the call fails, this error code is returned.
+        ///     The most common case for this failure is if the dependent library is missing some of its dependencies (for example the necessary CRT is missing on the machine).
+        ///     
+        ///      Probably means corrupted or incomplete installation.
+        /// </remarks>
+        CoreHostLibLoadFailure = unchecked((int)0x80008082),
+
+        /// <summary>
+        ///     One of the dependent libraries is missing.
+        /// </summary>
+        /// <remarks>
+        ///     Typically when the <c>hostfxr</c>, <c>hostpolicy</c>, or <c>coreclr</c> dynamic libraries are not present in the expected locations.
+        ///     
+        ///     Probably means corrupted or incomplete installation.
+        /// </remarks>
+        CoreHostLibMissingFailure = unchecked((int)0x80008083),
+
+        /// <summary>
+        ///     One of the dependent libraries is missing a required entry point.
+        /// </summary>
+        CoreHostEntryPointFailure = unchecked((int)0x80008084),
+
+        /// <summary>
+        ///     The hosting component is trying to use the path to the current module (the hosting component itself) and, from it, deduce the location of the installation, but either the location of the current module could not be determined (some weird OS call failure) or the location is not in the right place relative to other expected components.
+        /// </summary>
+        /// <remarks>
+        ///     For example the <c>hostfxr</c> may look at its location and try to deduce the location of the <c>shared</c> folder with the framework from it; it assumes the typical install layout on disk but if that doesn't work, then this error will be returned.
+        /// </remarks>
+        CoreHostCurHostFindFailure = unchecked((int)0x80008085),
+
+        /// <summary>
+        ///     The <c>coreclr</c> library could not be found.
+        /// </summary>
+        /// <remarks>
+        ///     The hosting layer (<c>hostpolicy</c>) looks for the <c>coreclr</c> library either next to the app itself (for self-contained) or in the root framework (for framework-dependent).
+        ///     This search can be done purely by looking at disk or more commonly by looking into the respective <c>.deps.json</c>. If the <c>coreclr</c> library is missing in <c>.deps.json</c> or it's there but doesn't exist on disk, then this error is returned.
+        /// </remarks>
+        CoreClrResolveFailure = unchecked((int)0x80008087),
+
+        /// <summary>
+        ///     The loaded <c>coreclr</c> library doesn't have one of the required entry points.
+        /// </summary>
+        CoreClrBindFailure = unchecked((int)0x80008088),
+
+        /// <summary>
+        ///     The call to <c>coreclr_initialize</c> failed.
+        /// </summary>
+        /// <remarks>
+        ///     The actual error returned by coreclr is reported in the error message.
+        /// </remarks>
+        CoreClrInitFailure = unchecked((int)0x80008089),
+
+        /// <summary>
+        ///     The call to <c>coreclr_execute_assembly</c> failed.
+        /// </summary>
+        /// <remarks>
+        ///     Note that this failure does not relate to the app's exit code; it occurs if <c>coreclr</c> failed to run the app itself.
+        /// </remarks>
+        CoreClrExeFailure = unchecked((int)0x8000808a),
+
+        /// <summary>
+        ///     Initialization of the <c>hostpolicy</c> dependency resolver failed.
+        /// </summary>
+        /// <remarks>
+        ///     Possible causes:
+        ///     <list type="bullet">
+        ///         <item>One of the <c>.deps.json</c> files is invalid (invalid JSON, or missing required properties and so on).</item>
+        ///         <item>One of the frameworks or the app is missing a required <c>.deps.json</c> file.</item>
+        ///     </list>
+        /// </remarks>
+        ResolverInitFailure = unchecked((int)0x8000808b),
+
+        /// <summary>
+        ///     Resolution of dependencies in <c>hostpolicy</c> failed.
+        /// </summary>
+        /// <remarks>
+        ///     This can have several different causes but, in general, it means that one of the processed <c>.deps.json</c> contains an entry for a file which could not found, or its resolution failed for some other reason (conflict for example).
+        /// </remarks>
+        ResolverResolveFailure = unchecked((int)0x8000808c),
+
+        /// <summary>
+        ///     Failure to determine the location of the current executable.
+        /// </summary>
+        /// <remarks>
+        ///     The hosting layer uses the current executable path to deduce the install location (in some cases). If that path can't be obtained (OS call fails, or the returned path doesn't exist), then this error is returned.
+        /// </remarks>
+        LibHostCurExeFindFailure = unchecked((int)0x8000808d),
+
+        /// <summary>
+        ///     Initialization of the <c>hostpolicy</c> library failed.
+        /// </summary>
+        /// <remarks>
+        ///     The <c>corehost_load</c> method takes a structure with lot of initialization parameters.
+        ///     If the version of that structure doesn't match the expected value, this error code is returned.
+        ///     
+        ///     This would in general mean incompatibility between the <c>hostfxr</c> and <c>hostpolicy</c>, which should really only happen if somehow a newer <c>hostpolicy</c> is used by older <c>hostfxr</c>.
+        ///     Typically, that indicates a corrupted installation.
+        /// </remarks>
+        LibHostInitFailure = unchecked((int)0x8000808e),
+
+        /// <summary>
+        ///     Failure to find the requested SDK.
+        /// </summary>
+        /// <remarks>
+        ///     This happens in the <c>hostfxr</c> when an SDK (also called CLI) command is used with dotnet.
+        ///     In this case, the hosting layer tries to find an installed .NET SDK to run the command on.
+        ///     The search is based on deduced install location and on the requested version (potentially from a <c>global.json</c> file).
+        ///     If either no matching SDK version can be found, or that version exists, but it's missing the dotnet.dll file, this error code is returned.
+        /// </remarks>
+        LibHostSdkFindFailure = unchecked((int)0x80008091),
+
+        /// <summary>
+        ///     Arguments to <c>hostpolicy</c> are invalid.
+        /// </summary>
+        /// <remarks>
+        ///     This is used in three unrelated places in the <c>hostpolicy</c> but, in all cases, it means that the component calling <c>hostpolicy</c> did something wrong
+        /// </remarks>
+        LibHostInvalidArgs = unchecked((int)0x80008092),
+
+        /// <summary>
+        ///     The .runtimeconfig.json file is invalid.
+        /// </summary>
+        /// <remarks>
+        ///     The reasons for this failure can include:
+        ///     
+        ///     <list type="bullet">
+        ///         <item>Failure to read from the file</item>
+        ///         <item>Invalid JSON</item>
+        ///         <item>Invalid value for a property (for example number for property which requires a string)</item>
+        ///         <item>Missing required property</item>
+        ///         <item>Other inconsistencies (for example <c>rollForward</c> and <c>applyPatches</c> are not allowed to be specified in the same config file)</item>
+        ///         <item>Any of the above failures reading the <c>.runtimecofig.dev.json</c> file</item>
+        ///         <item>Self-contained <c>.runtimeconfig.json</c> used in <c>hostfxr_initialize_for_runtime_config</c>. Note that missing <c>.runtimconfig.json</c> is not an error (means self-contained app).</item>
+        ///     </list>
+        ///     
+        ///     It is also used when there is a problem reading the CLSID map file in comhost.
+        /// </remarks>
+        InvalidConfigFile = unchecked((int)0x80008093),
+
+        /// <summary>
+        ///     Used internally when the command line for <c>dotnet.exe</c> doesn't contain path to the application to run.
+        /// </summary>
+        /// <remarks>
+        ///     In this scenario, the command line is considered to be a CLI/SDK command. This error code should never be returned to an external caller.
+        /// </remarks>
+        AppArgNotRunnable = unchecked((int)0x80008094),
+
+        /// <summary>
+        ///     <c>apphost</c> failed to determine which application to run.
+        /// </summary>
+        /// <remarks>
+        ///     The reasons for this failure can include:
+        ///     
+        ///     <list type="bullet">
+        ///         <item>The <c>apphost</c> binary has not been imprinted with the path to the app to run (so freshly built <c>apphost.exe</c> from the branch will fail to run like this)</item>
+        ///         <item>The <c>apphost</c> is a bundle (single-file exe) and it failed to extract correctly</item>
+        ///         <item>The <c>apphost</c> binary has been imprinted with invalid .NET search options</item>
+        ///     </list>
+        /// </remarks>
+        AppHostExeNotBoundFailure = unchecked((int)0x80008095),
+
+        /// <summary>
+        ///     It was not possible to find a compatible framework version.
+        /// </summary>
+        /// <remarks>
+        ///     This exit code originates in <c>hostfxr</c> (<c>resolve_framework_reference</c>), and means that the app specified a reference to a framework in its <c>.runtimeconfig.json</c> which could not be resolved.
+        ///     The failure to resolve can mean that no such framework is available on the disk, or that the available frameworks don't match the minimum version specified or that the roll forward options specified excluded all available frameworks.
+        ///     
+        ///     Typically, it would be returned if, for example, a 3.0 app is trying to run on a machine which has no 3.0 installed or a 32bit 3.0 app is running on a machine which has 3.0 installed but only for 64bit.
+        /// </remarks>
+        FrameworkMissingFailure = unchecked((int)0x80008096),
+
+        /// <summary>
+        ///     Returned by <c>hostfxr_get_native_search_directories</c> if the <c>hostpolicy</c> could not calculate the <c>NATIVE_DLL_SEARCH_DIRECTORIES</c>.
+        /// </summary>
+        HostApiFailed = unchecked((int)0x80008097),
+
+        /// <summary>
+        ///     Returned when the buffer specified to an API is not big enough to fit the requested value. 
+        /// </summary>
+        /// <remarks>
+        ///     Can be returned from:
+        ///     
+        ///     <list type="bullet">
+        ///         <item><c>hostfxr_get_runtime_properties</c></item>
+        ///         <item><c>hostfxr_get_native_search_directories</c></item>
+        ///         <item><c>get_hostfxr_path</c></item>
+        ///     </list>
+        /// </remarks>
+        HostApiBufferTooSmall = unchecked((int)0x80008098),
+
+        /// <summary>
+        ///     Returned by <c>hostpolicy</c> if the corehost_main_with_output_buffer is called with unsupported host command.
+        /// </summary>
+        /// <remarks>
+        ///     This error code means there is incompatibility between the <c>hostfxr</c> and <c>hostpolicy</c>. In reality, this should pretty much never happen.
+        /// </remarks>
+        LibHostUnknownCommand = unchecked((int)0x80008099),
+
+        /// <summary>
+        ///     Returned by <c>apphost</c> if the imprinted application path doesn't exist.
+        /// </summary>
+        /// <remarks>
+        ///     This would happen if the app is built with an executable (the apphost) and the main app.dll is missing.
+        /// </remarks>
+        LibHostAppRootFindFailure = unchecked((int)0x8000809a),
+
+        /// <summary>
+        ///     Returned from <c>hostfxr_resolve_sdk2</c> when it fails to find a matching SDK.
+        /// </summary>
+        /// <remarks>
+        ///     Similar to <c>LibHostSdkFindFailure</c>, but only used in the <c>hostfxr_resolve_sdk2</c>.
+        /// </remarks>
+        SdkResolverResolveFailure = unchecked((int)0x8000809b),
+
+        /// <summary>
+        ///     During processing of .runtimeconfig.json there were two framework references to the same framework which were not compatible.
+        /// </summary>
+        /// <remarks>
+        ///     This can happen if the app specified a framework reference to a lower-level framework which is also specified by a higher-level framework which is also used by the app.
+        ///     For example, this would happen if the app referenced Microsoft.AspNet.App version 2.0 and Microsoft.NETCore.App version 3.0.
+        ///     In such case the Microsoft.AspNet.App has .runtimeconfig.json which also references Microsoft.NETCore.App but it only allows versions 2.0 up to 2.9 (via roll forward options).
+        ///     So the version 3.0 requested by the app is incompatible.
+        /// </remarks>
+        FrameworkCompatFailure = unchecked((int)0x8000809c),
+
+        /// <summary>
+        ///     Error used internally if the processing of framework references from .runtimeconfig.json reached a point where it needs to reprocess another already processed framework reference.
+        /// </summary>
+        /// <remarks>
+        ///     If this error is returned to the external caller, it would mean there's a bug in the framework resolution algorithm.
+        /// </remarks>
+        FrameworkCompatRetry = unchecked((int)0x8000809d),
+
+        /// <summary>
+        ///     Error reading the bundle footer metadata from a single-file <c>apphost</c>.
+        /// </summary>
+        /// <remarks>
+        ///     This indicates a corrupted <c>apphost</c>.
+        /// </remarks>
+        AppHostExeNotBundle = unchecked((int)0x8000809e),
+
+        /// <summary>
+        ///     Error extracting single-file apphost bundle.
+        /// </summary>
+        /// <remarks>
+        ///     This is used in case of any error related to the bundle itself. Typically would mean a corrupted bundle.
+        /// </remarks>
+        BundleExtractionFailure = unchecked((int)0x8000809f),
+
+        /// <summary>
+        ///     Error reading or writing files during single-file apphost bundle extraction.
+        /// </summary>
+        BundleExtractionIOError = unchecked((int)0x800080a0),
+
+        /// <summary>
+        ///     The .runtimeconfig.json specified by the app contains a runtime property which is also produced by the hosting layer.
+        /// </summary>
+        /// <remarks>
+        ///     For example if the .runtimeconfig.json would specify a property TRUSTED_PLATFORM_ROOTS, this error code would be returned.
+        ///     It is not allowed to specify properties which are otherwise populated by the hosting layer (<c>hostpolicy</c>) as there is not good way to resolve such conflicts.
+        /// </remarks>
+        LibHostDuplicateProperty = unchecked((int)0x800080a1),
+
+        /// <summary>
+        ///     Feature which requires certain version of the hosting layer binaries was used on a version which doesn't support it.
+        /// </summary>
+        /// <remarks>
+        ///     For example if a COM component specified to run on 2.0 Microsoft.NETCore.App - as that contains older version of <c>hostpolicy</c> which doesn't support the necessary features to provide COM services.
+        /// </remarks>
+        HostApiUnsupportedVersion = unchecked((int)0x800080a2),
+        
+        /// <summary>
+        ///     Error code returned by the hosting APIs in <c>hostfxr</c> if the current state is incompatible with the requested operation. 
+        /// </summary>
+        HostInvalidState = unchecked((int)0x800080a3),
+
+        /// <summary>
+        ///     A property requested by <c>hostfxr_get_runtime_property_value</c> doesn't exist.
+        /// </summary>
+        HostPropertyNotFound = unchecked((int)0x800080a4),
+
+        /// <summary>
+        ///     Error returned by <c>hostfxr_initialize_for_runtime_config</c> if the component being initialized requires framework which is not available or incompatible with the frameworks loaded by the runtime already in the process.
+        /// </summary>
+        /// <remarks>
+        ///     For example trying to load a component which requires 3.0 into a process which is already running a 2.0 runtime.
+        /// </remarks>
+        CoreHostIncompatibleConfig = unchecked((int)0x800080a5),
+
+        /// <summary>
+        ///     Error returned by <c>hostfxr_get_runtime_delegate</c> when <c>hostfxr</c> doesn't currently support requesting the given delegate type using the given context.
+        /// </summary>
+        HostApiUnsupportedScenario = unchecked((int)0x800080a6),
+
+        /// <summary>
+        ///     Error returned by <c>hostfxr_get_runtime_delegate</c> when managed feature support for native host is disabled.
+        /// </summary>
+        HostFeatureDisabled = unchecked((int)0x800080a7),
     }
 }

--- a/src/LanguageServer.Common/Utilities/DotnetInfo.cs
+++ b/src/LanguageServer.Common/Utilities/DotnetInfo.cs
@@ -380,26 +380,13 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
     public abstract class DotnetInfoException
         : Exception
     {
-        /// <summary>
-        ///     Create a new <see cref="DotnetInfoException"/>.
-        /// </summary>
-        /// <param name="message">
-        ///     The exception message.
-        /// </param>
+        /// <inheritdoc cref="Exception(string)" />
         protected DotnetInfoException(string message)
             : base(message)
         {
         }
 
-        /// <summary>
-        ///     Create a new <see cref="DotnetInfoException"/>.
-        /// </summary>
-        /// <param name="message">
-        ///     The exception message.
-        /// </param>
-        /// <param name="innerException">
-        ///     The exception that caused the <see cref="DotnetInfoException"/> to be raised.
-        /// </param>
+        /// <inheritdoc cref="Exception(string, Exception)" />
         protected DotnetInfoException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -412,26 +399,13 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
     public class DotnetDiscoveryException
         : DotnetInfoException
     {
-        /// <summary>
-        ///     Create a new <see cref="DotnetDiscoveryException"/>.
-        /// </summary>
-        /// <param name="message">
-        ///     The exception message.
-        /// </param>
+        /// <inheritdoc cref="Exception(string)" />
         public DotnetDiscoveryException(string message)
             : base(message)
         {
         }
 
-        /// <summary>
-        ///     Create a new <see cref="DotnetDiscoveryException"/>.
-        /// </summary>
-        /// <param name="message">
-        ///     The exception message.
-        /// </param>
-        /// <param name="innerException">
-        ///     The exception that caused the <see cref="DotnetDiscoveryException"/> to be raised.
-        /// </param>
+        /// <inheritdoc cref="Exception(string, Exception)" />
         public DotnetDiscoveryException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -498,6 +472,8 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
     /// </summary>
     /// <remarks>
     ///     Derived from <seealso href="https://github.com/dotnet/runtime/blob/d123560a23078989f9563b83fa49a24802e88378/docs/design/features/host-error-codes.md"/>.
+    ///     
+    ///     Note that these exit codes are basically HRESULTs.
     /// </remarks>
     public enum DotNetHostExitCode
     {
@@ -509,7 +485,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <summary>
         ///     One of the specified arguments for the operation is invalid.
         /// </summary>
-        InvalidArgFailure = unchecked((int)0x80008081),
+        InvalidArgFailure = -2147450751,
 
         /// <summary>
         ///     There was a failure loading a dependent library.
@@ -520,7 +496,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     
         ///      Probably means corrupted or incomplete installation.
         /// </remarks>
-        CoreHostLibLoadFailure = unchecked((int)0x80008082),
+        CoreHostLibLoadFailure = -2147450750,
 
         /// <summary>
         ///     One of the dependent libraries is missing.
@@ -530,12 +506,12 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     
         ///     Probably means corrupted or incomplete installation.
         /// </remarks>
-        CoreHostLibMissingFailure = unchecked((int)0x80008083),
+        CoreHostLibMissingFailure = -2147450749,
 
         /// <summary>
         ///     One of the dependent libraries is missing a required entry point.
         /// </summary>
-        CoreHostEntryPointFailure = unchecked((int)0x80008084),
+        CoreHostEntryPointFailure = -2147450748,
 
         /// <summary>
         ///     The hosting component is trying to use the path to the current module (the hosting component itself) and, from it, deduce the location of the installation, but either the location of the current module could not be determined (some weird OS call failure) or the location is not in the right place relative to other expected components.
@@ -543,7 +519,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <remarks>
         ///     For example the <c>hostfxr</c> may look at its location and try to deduce the location of the <c>shared</c> folder with the framework from it; it assumes the typical install layout on disk but if that doesn't work, then this error will be returned.
         /// </remarks>
-        CoreHostCurHostFindFailure = unchecked((int)0x80008085),
+        CoreHostCurHostFindFailure = -2147450747,
 
         /// <summary>
         ///     Initialization of the <c>hostpolicy</c> dependency resolver failed.
@@ -555,7 +531,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///         <item>One of the frameworks or the app is missing a required <c>.deps.json</c> file.</item>
         ///     </list>
         /// </remarks>
-        ResolverInitFailure = unchecked((int)0x8000808b),
+        ResolverInitFailure = -2147450741,
 
         /// <summary>
         ///     Resolution of dependencies in <c>hostpolicy</c> failed.
@@ -563,7 +539,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <remarks>
         ///     This can have several different causes but, in general, it means that one of the processed <c>.deps.json</c> contains an entry for a file which could not found, or its resolution failed for some other reason (conflict for example).
         /// </remarks>
-        ResolverResolveFailure = unchecked((int)0x8000808c),
+        ResolverResolveFailure = -2147450740,
 
         /// <summary>
         ///     Failure to determine the location of the current executable.
@@ -571,7 +547,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <remarks>
         ///     The hosting layer uses the current executable path to deduce the install location (in some cases). If that path can't be obtained (OS call fails, or the returned path doesn't exist), then this error is returned.
         /// </remarks>
-        LibHostCurExeFindFailure = unchecked((int)0x8000808d),
+        LibHostCurExeFindFailure = -2147450739,
 
         /// <summary>
         ///     Initialization of the <c>hostpolicy</c> library failed.
@@ -583,7 +559,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     This would in general mean incompatibility between the <c>hostfxr</c> and <c>hostpolicy</c>, which should really only happen if somehow a newer <c>hostpolicy</c> is used by older <c>hostfxr</c>.
         ///     Typically, that indicates a corrupted installation.
         /// </remarks>
-        LibHostInitFailure = unchecked((int)0x8000808e),
+        LibHostInitFailure = -2147450738,
 
         /// <summary>
         ///     Failure to find the requested SDK.
@@ -594,7 +570,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     The search is based on deduced install location and on the requested version (potentially from a <c>global.json</c> file).
         ///     If either no matching SDK version can be found, or that version exists, but it's missing the dotnet.dll file, this error code is returned.
         /// </remarks>
-        LibHostSdkFindFailure = unchecked((int)0x80008091),
+        LibHostSdkFindFailure = -2147450735,
 
         /// <summary>
         ///     The .runtimeconfig.json file is invalid.
@@ -614,7 +590,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     
         ///     It is also used when there is a problem reading the CLSID map file in comhost.
         /// </remarks>
-        InvalidConfigFile = unchecked((int)0x80008093),
+        InvalidConfigFile = -2147450733,
 
         /// <summary>
         ///     It was not possible to find a compatible framework version.
@@ -625,12 +601,12 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     
         ///     Typically, it would be returned if, for example, a 3.0 app is trying to run on a machine which has no 3.0 installed or a 32bit 3.0 app is running on a machine which has 3.0 installed but only for 64bit.
         /// </remarks>
-        FrameworkMissingFailure = unchecked((int)0x80008096),
+        FrameworkMissingFailure = -2147450730,
 
         /// <summary>
         ///     Returned by <c>hostfxr_get_native_search_directories</c> if the <c>hostpolicy</c> could not calculate the <c>NATIVE_DLL_SEARCH_DIRECTORIES</c>.
         /// </summary>
-        HostApiFailed = unchecked((int)0x80008097),
+        HostApiFailed = -2147450729,
 
         /// <summary>
         ///     Returned from <c>hostfxr_resolve_sdk2</c> when it fails to find a matching SDK.
@@ -638,7 +614,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <remarks>
         ///     Similar to <c>LibHostSdkFindFailure</c>, but only used in the <c>hostfxr_resolve_sdk2</c>.
         /// </remarks>
-        SdkResolverResolveFailure = unchecked((int)0x8000809b),
+        SdkResolverResolveFailure = -2147450725,
 
         /// <summary>
         ///     During processing of .runtimeconfig.json there were two framework references to the same framework which were not compatible.
@@ -649,7 +625,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     In such case the Microsoft.AspNet.App has .runtimeconfig.json which also references Microsoft.NETCore.App but it only allows versions 2.0 up to 2.9 (via roll forward options).
         ///     So the version 3.0 requested by the app is incompatible.
         /// </remarks>
-        FrameworkCompatFailure = unchecked((int)0x8000809c),
+        FrameworkCompatFailure = -2147450724,
 
         /// <summary>
         ///     Feature which requires certain version of the hosting layer binaries was used on a version which doesn't support it.
@@ -657,15 +633,15 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <remarks>
         ///     For example if a COM component specified to run on 2.0 Microsoft.NETCore.App - as that contains older version of <c>hostpolicy</c> which doesn't support the necessary features to provide COM services.
         /// </remarks>
-        HostApiUnsupportedVersion = unchecked((int)0x800080a2),
-        
+        HostApiUnsupportedVersion = -2147450718,
+
         /// <summary>
         ///     Error returned by <c>hostfxr_initialize_for_runtime_config</c> if the component being initialized requires framework which is not available or incompatible with the frameworks loaded by the runtime already in the process.
         /// </summary>
         /// <remarks>
         ///     For example trying to load a component which requires 3.0 into a process which is already running a 2.0 runtime.
         /// </remarks>
-        CoreHostIncompatibleConfig = unchecked((int)0x800080a5),
+        CoreHostIncompatibleConfig = -2147450715,
     }
 
     /// <summary>

--- a/src/LanguageServer.Common/Utilities/DotnetInfo.cs
+++ b/src/LanguageServer.Common/Utilities/DotnetInfo.cs
@@ -507,22 +507,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         Success = 0,
 
         /// <summary>
-        ///     Initialization was successful, but another host context is already initialized, so the returned context is "secondary" (the requested context was otherwise fully compatible with the already initialized context).
-        /// </summary>
-        /// <remarks>
-        ///     Probably not used as an actual exit code; returned by <c>hostfxr_initialize_for_runtime_config</c> if it's called when the host is already initialized in the process.
-        /// </remarks>
-        Success_HostAlreadyInitialized = 0x00000001,
-
-        /// <summary>
-        ///     Initialization was successful, but another host context is already initialized and the requested context specified some runtime properties which are not the same (either in value or in presence) to the already initialized context.
-        /// </summary>
-        /// <remarks>
-        ///     Probably not used as an actual exit code; returned by <c>hostfxr_initialize_for_runtime_config</c> if it's called when the host is already initialized in the process.
-        /// </remarks>
-        Success_DifferentRuntimeProperties = 0x00000002,
-
-        /// <summary>
         ///     One of the specified arguments for the operation is invalid.
         /// </summary>
         InvalidArgFailure = unchecked((int)0x80008081),
@@ -560,36 +544,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     For example the <c>hostfxr</c> may look at its location and try to deduce the location of the <c>shared</c> folder with the framework from it; it assumes the typical install layout on disk but if that doesn't work, then this error will be returned.
         /// </remarks>
         CoreHostCurHostFindFailure = unchecked((int)0x80008085),
-
-        /// <summary>
-        ///     The <c>coreclr</c> library could not be found.
-        /// </summary>
-        /// <remarks>
-        ///     The hosting layer (<c>hostpolicy</c>) looks for the <c>coreclr</c> library either next to the app itself (for self-contained) or in the root framework (for framework-dependent).
-        ///     This search can be done purely by looking at disk or more commonly by looking into the respective <c>.deps.json</c>. If the <c>coreclr</c> library is missing in <c>.deps.json</c> or it's there but doesn't exist on disk, then this error is returned.
-        /// </remarks>
-        CoreClrResolveFailure = unchecked((int)0x80008087),
-
-        /// <summary>
-        ///     The loaded <c>coreclr</c> library doesn't have one of the required entry points.
-        /// </summary>
-        CoreClrBindFailure = unchecked((int)0x80008088),
-
-        /// <summary>
-        ///     The call to <c>coreclr_initialize</c> failed.
-        /// </summary>
-        /// <remarks>
-        ///     The actual error returned by coreclr is reported in the error message.
-        /// </remarks>
-        CoreClrInitFailure = unchecked((int)0x80008089),
-
-        /// <summary>
-        ///     The call to <c>coreclr_execute_assembly</c> failed.
-        /// </summary>
-        /// <remarks>
-        ///     Note that this failure does not relate to the app's exit code; it occurs if <c>coreclr</c> failed to run the app itself.
-        /// </remarks>
-        CoreClrExeFailure = unchecked((int)0x8000808a),
 
         /// <summary>
         ///     Initialization of the <c>hostpolicy</c> dependency resolver failed.
@@ -643,14 +597,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         LibHostSdkFindFailure = unchecked((int)0x80008091),
 
         /// <summary>
-        ///     Arguments to <c>hostpolicy</c> are invalid.
-        /// </summary>
-        /// <remarks>
-        ///     This is used in three unrelated places in the <c>hostpolicy</c> but, in all cases, it means that the component calling <c>hostpolicy</c> did something wrong
-        /// </remarks>
-        LibHostInvalidArgs = unchecked((int)0x80008092),
-
-        /// <summary>
         ///     The .runtimeconfig.json file is invalid.
         /// </summary>
         /// <remarks>
@@ -671,28 +617,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         InvalidConfigFile = unchecked((int)0x80008093),
 
         /// <summary>
-        ///     Used internally when the command line for <c>dotnet.exe</c> doesn't contain path to the application to run.
-        /// </summary>
-        /// <remarks>
-        ///     In this scenario, the command line is considered to be a CLI/SDK command. This error code should never be returned to an external caller.
-        /// </remarks>
-        AppArgNotRunnable = unchecked((int)0x80008094),
-
-        /// <summary>
-        ///     <c>apphost</c> failed to determine which application to run.
-        /// </summary>
-        /// <remarks>
-        ///     The reasons for this failure can include:
-        ///     
-        ///     <list type="bullet">
-        ///         <item>The <c>apphost</c> binary has not been imprinted with the path to the app to run (so freshly built <c>apphost.exe</c> from the branch will fail to run like this)</item>
-        ///         <item>The <c>apphost</c> is a bundle (single-file exe) and it failed to extract correctly</item>
-        ///         <item>The <c>apphost</c> binary has been imprinted with invalid .NET search options</item>
-        ///     </list>
-        /// </remarks>
-        AppHostExeNotBoundFailure = unchecked((int)0x80008095),
-
-        /// <summary>
         ///     It was not possible to find a compatible framework version.
         /// </summary>
         /// <remarks>
@@ -707,36 +631,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     Returned by <c>hostfxr_get_native_search_directories</c> if the <c>hostpolicy</c> could not calculate the <c>NATIVE_DLL_SEARCH_DIRECTORIES</c>.
         /// </summary>
         HostApiFailed = unchecked((int)0x80008097),
-
-        /// <summary>
-        ///     Returned when the buffer specified to an API is not big enough to fit the requested value. 
-        /// </summary>
-        /// <remarks>
-        ///     Can be returned from:
-        ///     
-        ///     <list type="bullet">
-        ///         <item><c>hostfxr_get_runtime_properties</c></item>
-        ///         <item><c>hostfxr_get_native_search_directories</c></item>
-        ///         <item><c>get_hostfxr_path</c></item>
-        ///     </list>
-        /// </remarks>
-        HostApiBufferTooSmall = unchecked((int)0x80008098),
-
-        /// <summary>
-        ///     Returned by <c>hostpolicy</c> if the corehost_main_with_output_buffer is called with unsupported host command.
-        /// </summary>
-        /// <remarks>
-        ///     This error code means there is incompatibility between the <c>hostfxr</c> and <c>hostpolicy</c>. In reality, this should pretty much never happen.
-        /// </remarks>
-        LibHostUnknownCommand = unchecked((int)0x80008099),
-
-        /// <summary>
-        ///     Returned by <c>apphost</c> if the imprinted application path doesn't exist.
-        /// </summary>
-        /// <remarks>
-        ///     This would happen if the app is built with an executable (the apphost) and the main app.dll is missing.
-        /// </remarks>
-        LibHostAppRootFindFailure = unchecked((int)0x8000809a),
 
         /// <summary>
         ///     Returned from <c>hostfxr_resolve_sdk2</c> when it fails to find a matching SDK.
@@ -758,44 +652,6 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         FrameworkCompatFailure = unchecked((int)0x8000809c),
 
         /// <summary>
-        ///     Error used internally if the processing of framework references from .runtimeconfig.json reached a point where it needs to reprocess another already processed framework reference.
-        /// </summary>
-        /// <remarks>
-        ///     If this error is returned to the external caller, it would mean there's a bug in the framework resolution algorithm.
-        /// </remarks>
-        FrameworkCompatRetry = unchecked((int)0x8000809d),
-
-        /// <summary>
-        ///     Error reading the bundle footer metadata from a single-file <c>apphost</c>.
-        /// </summary>
-        /// <remarks>
-        ///     This indicates a corrupted <c>apphost</c>.
-        /// </remarks>
-        AppHostExeNotBundle = unchecked((int)0x8000809e),
-
-        /// <summary>
-        ///     Error extracting single-file apphost bundle.
-        /// </summary>
-        /// <remarks>
-        ///     This is used in case of any error related to the bundle itself. Typically would mean a corrupted bundle.
-        /// </remarks>
-        BundleExtractionFailure = unchecked((int)0x8000809f),
-
-        /// <summary>
-        ///     Error reading or writing files during single-file apphost bundle extraction.
-        /// </summary>
-        BundleExtractionIOError = unchecked((int)0x800080a0),
-
-        /// <summary>
-        ///     The .runtimeconfig.json specified by the app contains a runtime property which is also produced by the hosting layer.
-        /// </summary>
-        /// <remarks>
-        ///     For example if the .runtimeconfig.json would specify a property TRUSTED_PLATFORM_ROOTS, this error code would be returned.
-        ///     It is not allowed to specify properties which are otherwise populated by the hosting layer (<c>hostpolicy</c>) as there is not good way to resolve such conflicts.
-        /// </remarks>
-        LibHostDuplicateProperty = unchecked((int)0x800080a1),
-
-        /// <summary>
         ///     Feature which requires certain version of the hosting layer binaries was used on a version which doesn't support it.
         /// </summary>
         /// <remarks>
@@ -804,32 +660,12 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         HostApiUnsupportedVersion = unchecked((int)0x800080a2),
         
         /// <summary>
-        ///     Error code returned by the hosting APIs in <c>hostfxr</c> if the current state is incompatible with the requested operation. 
-        /// </summary>
-        HostInvalidState = unchecked((int)0x800080a3),
-
-        /// <summary>
-        ///     A property requested by <c>hostfxr_get_runtime_property_value</c> doesn't exist.
-        /// </summary>
-        HostPropertyNotFound = unchecked((int)0x800080a4),
-
-        /// <summary>
         ///     Error returned by <c>hostfxr_initialize_for_runtime_config</c> if the component being initialized requires framework which is not available or incompatible with the frameworks loaded by the runtime already in the process.
         /// </summary>
         /// <remarks>
         ///     For example trying to load a component which requires 3.0 into a process which is already running a 2.0 runtime.
         /// </remarks>
         CoreHostIncompatibleConfig = unchecked((int)0x800080a5),
-
-        /// <summary>
-        ///     Error returned by <c>hostfxr_get_runtime_delegate</c> when <c>hostfxr</c> doesn't currently support requesting the given delegate type using the given context.
-        /// </summary>
-        HostApiUnsupportedScenario = unchecked((int)0x800080a6),
-
-        /// <summary>
-        ///     Error returned by <c>hostfxr_get_runtime_delegate</c> when managed feature support for native host is disabled.
-        /// </summary>
-        HostFeatureDisabled = unchecked((int)0x800080a7),
     }
 
     /// <summary>

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -87,11 +87,11 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             // This will also ensure that the language server's model doesn't expose any MSBuild objects anywhere.
             //
             // For now, though, let's choose the dumb option.
-            var runtimeInfo = DotNetRuntimeInfo.GetCurrent(baseDirectory, logger);
+            var dotnetInfo = DotnetInfo.GetCurrent(baseDirectory, logger);
 
             // SDK versions are in SemVer format...
-            if (!SemanticVersion.TryParse(runtimeInfo.SdkVersion, out SemanticVersion targetSdkSemanticVersion))
-                throw new Exception($"Cannot determine SDK version information for current .NET SDK (located at '{runtimeInfo.BaseDirectory}').");
+            if (!SemanticVersion.TryParse(dotnetInfo.SdkVersion, out SemanticVersion targetSdkSemanticVersion))
+                throw new Exception($"Cannot determine SDK version information for current .NET SDK (located at '{dotnetInfo.BaseDirectory}').");
 
             // ...which MSBuildLocator does not understand.
             var targetSdkVersion = new Version(
@@ -141,7 +141,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             logger ??= Log.Logger;
 
             return CreateProjectCollection(solutionDirectory,
-                DotNetRuntimeInfo.GetCurrent(solutionDirectory, logger),
+                DotnetInfo.GetCurrent(solutionDirectory, logger),
                 globalPropertyOverrides
             );
         }
@@ -161,7 +161,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <returns>
         ///     The project collection.
         /// </returns>
-        public static ProjectCollection CreateProjectCollection(string solutionDirectory, DotNetRuntimeInfo runtimeInfo, Dictionary<string, string> globalPropertyOverrides = null)
+        public static ProjectCollection CreateProjectCollection(string solutionDirectory, DotnetInfo runtimeInfo, Dictionary<string, string> globalPropertyOverrides = null)
         {
             if (string.IsNullOrWhiteSpace(solutionDirectory))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'baseDir'.", nameof(solutionDirectory));
@@ -216,7 +216,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <returns>
         ///     A dictionary containing the global properties.
         /// </returns>
-        public static Dictionary<string, string> CreateGlobalMSBuildProperties(DotNetRuntimeInfo runtimeInfo, string solutionDirectory, Dictionary<string, string> globalPropertyOverrides = null)
+        public static Dictionary<string, string> CreateGlobalMSBuildProperties(DotnetInfo runtimeInfo, string solutionDirectory, Dictionary<string, string> globalPropertyOverrides = null)
         {
             if (runtimeInfo == null)
                 throw new ArgumentNullException(nameof(runtimeInfo));

--- a/src/LanguageServer.Engine/Documents/ProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/ProjectDocument.cs
@@ -752,7 +752,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
             if (!HasMSBuildProject)
                 throw new InvalidOperationException($"MSBuild project '{ProjectFile.FullName}' is not loaded.");
 
-            var currentRuntime = DotNetRuntimeInfo.GetCurrent();
+            var currentRuntime = DotnetInfo.GetCurrent();
 
             var taskAssemblyFiles = new List<string>
             {

--- a/test/LanguageServer.Engine.Tests/TaskScannerTests.cs
+++ b/test/LanguageServer.Engine.Tests/TaskScannerTests.cs
@@ -37,19 +37,19 @@ namespace MSBuildProjectTools.LanguageServer.Tests
                 Log.Information("Runtime Directory = {RuntimeDirectory}", RuntimeEnvironment.GetRuntimeDirectory());
 
                 Environment.SetEnvironmentVariable("MSBUILD_PROJECT_TOOLS_DOTNET_HOST_DIAGNOSTICS", "1");
-                RuntimeInfo = DotnetInfo.GetCurrent(logger: Log);
+                CurrentDotnetInfo = DotnetInfo.GetCurrent(logger: Log);
                 Environment.SetEnvironmentVariable("MSBUILD_PROJECT_TOOLS_DOTNET_HOST_DIAGNOSTICS", null);
             }
             else
-                RuntimeInfo = DotnetInfo.GetCurrent();
+                CurrentDotnetInfo = DotnetInfo.GetCurrent();
 
-            Assert.NotNull(RuntimeInfo.BaseDirectory);
+            Assert.NotNull(CurrentDotnetInfo.BaseDirectory);
         }
 
         /// <summary>
         ///     Information about the current .NET runtime.
         /// </summary>
-        DotnetInfo RuntimeInfo { get; }
+        DotnetInfo CurrentDotnetInfo { get; }
 
         /// <summary>
         ///     Verify that the task scanner can retrieve task metadata from an assembly.
@@ -68,7 +68,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
                 $"Task assembly '{taskAssemblyFile}' exists"
             );
 
-            MSBuildTaskAssemblyMetadata metadata = MSBuildTaskScanner.GetAssemblyTaskMetadata(taskAssemblyFile, RuntimeInfo.Sdk, Log);
+            MSBuildTaskAssemblyMetadata metadata = MSBuildTaskScanner.GetAssemblyTaskMetadata(taskAssemblyFile, CurrentDotnetInfo.Sdk, Log);
             Assert.NotNull(metadata);
 
             Assert.NotEmpty(metadata.Tasks);
@@ -91,7 +91,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
             if (string.IsNullOrWhiteSpace(assemblyFileName))
                 throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(assemblyFileName)}.", nameof(assemblyFileName));
 
-            return Path.Combine(RuntimeInfo.BaseDirectory,
+            return Path.Combine(CurrentDotnetInfo.BaseDirectory,
                 assemblyFileName.Replace('/', Path.DirectorySeparatorChar)
             );
         }

--- a/test/LanguageServer.Engine.Tests/TaskScannerTests.cs
+++ b/test/LanguageServer.Engine.Tests/TaskScannerTests.cs
@@ -37,11 +37,11 @@ namespace MSBuildProjectTools.LanguageServer.Tests
                 Log.Information("Runtime Directory = {RuntimeDirectory}", RuntimeEnvironment.GetRuntimeDirectory());
 
                 Environment.SetEnvironmentVariable("MSBUILD_PROJECT_TOOLS_DOTNET_HOST_DIAGNOSTICS", "1");
-                RuntimeInfo = DotNetRuntimeInfo.GetCurrent(logger: Log);
+                RuntimeInfo = DotnetInfo.GetCurrent(logger: Log);
                 Environment.SetEnvironmentVariable("MSBUILD_PROJECT_TOOLS_DOTNET_HOST_DIAGNOSTICS", null);
             }
             else
-                RuntimeInfo = DotNetRuntimeInfo.GetCurrent();
+                RuntimeInfo = DotnetInfo.GetCurrent();
 
             Assert.NotNull(RuntimeInfo.BaseDirectory);
         }
@@ -49,7 +49,7 @@ namespace MSBuildProjectTools.LanguageServer.Tests
         /// <summary>
         ///     Information about the current .NET runtime.
         /// </summary>
-        DotNetRuntimeInfo RuntimeInfo { get; }
+        DotnetInfo RuntimeInfo { get; }
 
         /// <summary>
         ///     Verify that the task scanner can retrieve task metadata from an assembly.


### PR DESCRIPTION
Improve behaviour of .NET version detection when the .NET host cannot resolve a matching runtime or SDK for `global.json`.

The `dotnet` host has many known exit codes, but currently only a couple are currently of interest to us. I have nevertheless included all known exit codes in an enum since the exit-code names (rather than just hex numbers) are quite likely to aid future troubleshooting efforts.,

This PR only partially addresses tintoy/msbuild-project-tools-vscode#156 (the language server side), although, since VSCode's language client doesn't provide access to the process exit code, it's challenging (for the extension side) to reliably return user-facing error messages from the language server (in scenarios like this that occur before the LSP connection has been established).

We might want to consider changing our STDERR output, at some point, be JSON format so the extension has a better chance of interpreting it.