### PR TITLE
Correctly handle VSCode/LSP completion behaviour when triggered by one or more trigger characters

### DIFF
--- a/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
+++ b/src/LanguageServer.Engine/CompletionProviders/CompletionProvider.cs
@@ -94,13 +94,18 @@ namespace MSBuildProjectTools.LanguageServer.CompletionProviders
                 throw new ArgumentNullException(nameof(projectDocument));
 
             // Replace any characters that were typed to trigger the completion.
-            if (triggerCharacters != null)
+            if (!String.IsNullOrEmpty(triggerCharacters))
             {
-                targetRange = projectDocument.XmlPositions.ExtendLeft(targetRange, byCharCount: triggerCharacters.Length);
+                // The last character typed is implicitly part of the current selection, if it triggered completion.
+                int extendSelectionByCharCount = triggerCharacters.Length - 1;
+                if (extendSelectionByCharCount > 0)
+                {
+                    targetRange = projectDocument.XmlPositions.ExtendLeft(targetRange, extendSelectionByCharCount);
 
-                Log.Verbose("Completion was triggered by typing one or more characters; target range will be extended by {TriggerCharacterCount} characters toward start of document (now: {TargetRange}).", triggerCharacters.Length, targetRange);
+                    Log.Verbose("Completion was triggered by typing one or more characters; target range will be extended by {TriggerCharacterCount} characters toward start of document (now: {TargetRange}).", triggerCharacters.Length, targetRange);
 
-                return true;
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
In this scenario, the last character typed is implicitly treated as part of the current selection, if it triggered completion.

tintoy/msbuild-project-tools-vscode#93