### PR TITLE
Initial support for overriding global MSBuild properties

### DIFF
--- a/src/LanguageServer.Engine/Configuration.cs
+++ b/src/LanguageServer.Engine/Configuration.cs
@@ -169,6 +169,12 @@ namespace MSBuildProjectTools.LanguageServer
         }
 
         /// <summary>
+        ///     Overrides for default MSBuild properties used when a project is first loaded.
+        /// </summary>
+        [JsonProperty("globalProperties", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+        public Dictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         ///     Override the default value of MSBuildExtensionsPath.
         /// </summary>
         [JsonProperty("extensionsPath")]

--- a/src/LanguageServer.Engine/Documents/ProjectDocument.cs
+++ b/src/LanguageServer.Engine/Documents/ProjectDocument.cs
@@ -804,7 +804,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         /// </summary>
         protected virtual Dictionary<string, string> GetMSBuildGlobalPropertyOverrides()
         {
-            var propertyOverrides = new Dictionary<string, string>();
+            var propertyOverrides = new Dictionary<string, string>(Workspace.Configuration.MSBuild.GlobalProperties, Workspace.Configuration.MSBuild.GlobalProperties.Comparer);
             if (!string.IsNullOrWhiteSpace(Workspace.Configuration.MSBuild.ExtensionsPath))
                 propertyOverrides[MSBuildHelper.WellKnownPropertyNames.MSBuildExtensionsPath] = Workspace.Configuration.MSBuild.ExtensionsPath;
             if (!string.IsNullOrWhiteSpace(Workspace.Configuration.MSBuild.ExtensionsPath32))


### PR DESCRIPTION
This is the language-server component of tintoy/msbuild-project-tools-vscode#166:

Add a configuration option `Configuration.MSBuild.GlobalProperties` used to configure overrides of the default MSBuild properties used before a project is loaded. These overrides are then used when initialising the root MSBuild `ProjectCollection` that all projects are loaded into.

Note that, by design, this option is selectively overridden by more-specific property overrides (such as `Configuration.MSBuild.ExtensionsPath` and `Configuration.MSBuild.ExtensionsPath32`).


