### PR TITLE
Use Workspace.GetDocument instead of Workspace.GetProjectDocument in DefinitionHandler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,10 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+
+    <!--
+      Disable MSBuild reference check (not applicable to our scenario; see https://github.com/microsoft/MSBuildLocator/blob/55ff263d5a99f91a215c9ca5fbba8ccfa3371fe5/docs/diagnostics/MSBL001.md for details).
+    -->
+    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 
     <!-- Microsoft.Build -->
     <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
 
     <!-- Microsoft.VisualStudio -->
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
@@ -34,6 +34,7 @@
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="1.0.1" />
     
     <!-- NuGet -->
+    <PackageVersion Include="NuGet.Frameworks" Version="6.14.0" />
     <PackageVersion Include="NuGet.PackageManagement" Version="6.14.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
     

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -159,7 +159,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
 
                 logger.Error("Cannot locate MSBuild engine for .NET SDK v{TargetSdkVersion}. This probably means that MSBuild Project Tools cannot find the MSBuild for the current project instance. It did find the following version(s), though: [{FoundVersions}].",
                     targetFrameworkVersion,
-                    String.Join(", ", foundVersions)
+                    foundVersions
                 );
 
                 return null;

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -122,6 +122,51 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         }
 
         /// <summary>
+        ///     Find the earliest version of the MSBuild engine compatible with the specified target-framework version.
+        /// </summary>
+        /// <param name="targetFrameworkVersion">
+        ///     The target framework version to match.
+        /// </param>
+        /// <param name="logger">
+        ///     An optional <see cref="ILogger"/> to use for diagnostic purposes (if not specified, the static <see cref="Log.Logger"/> will be used).
+        /// </param>
+        /// <returns>
+        ///     A <see cref="VisualStudioInstance"/> representing the discovered version of the MSBuild engine, or <c>null</c> if no compatible version was found.
+        /// </returns>
+        public static VisualStudioInstance FindMSBuildEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger)
+        {
+            var allInstances = MSBuildLocator.QueryVisualStudioInstances();
+
+            string stv = string.Join(", ", allInstances.Select(instance => $"{instance.Version} ({instance.Name})"));
+
+            VisualStudioInstance firstCompatibleInstance = allInstances
+                .OrderBy(instance => instance.Version)
+                .FirstOrDefault(instance =>
+                    instance.Version.Major == targetFrameworkVersion.Major
+                    &&
+                    instance.Version.Minor == targetFrameworkVersion.Minor
+                    &&
+                    (
+                        targetFrameworkVersion.Build == -1 // Only match if specified.
+                        ||
+                        instance.Version.Build == targetFrameworkVersion.Build
+                    )
+                );
+
+            if (firstCompatibleInstance == null)
+            {
+                string foundVersions = string.Join(", ", allInstances.Select(instance => instance.Version));
+
+                logger.Error("Cannot locate MSBuild engine for .NET SDK v{TargetSdkVersion}. This probably means that MSBuild Project Tools cannot find the MSBuild for the current project instance. It did find the following version(s), though: [{FoundVersions}].",
+                    targetFrameworkVersion,
+                    String.Join(", ", foundVersions)
+                );
+            }
+
+            return firstCompatibleInstance;
+        }
+
+        /// <summary>
         ///     Create an MSBuild project collection.
         /// </summary>
         /// <param name="solutionDirectory">

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -135,7 +135,7 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// </returns>
         public static MSBuildEngineInstance FindEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger = null)
         {
-            logger ??= Serilog.Core.Logger.None;
+            logger ??= Log.Logger;
 
             VisualStudioInstance[] allInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
 

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -133,11 +133,11 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         /// <returns>
         ///     A <see cref="MSBuildEngineInstance"/> representing the discovered version of the MSBuild engine, or <c>null</c> if no compatible version was found.
         /// </returns>
-        public static MSBuildEngineInstance FindMSBuildEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger)
+        public static MSBuildEngineInstance FindEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger = null)
         {
-            var allInstances = MSBuildLocator.QueryVisualStudioInstances();
+            logger ??= Serilog.Core.Logger.None;
 
-            string stv = string.Join(", ", allInstances.Select(instance => $"{instance.Version} ({instance.Name})"));
+            VisualStudioInstance[] allInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
 
             VisualStudioInstance firstCompatibleInstance = allInstances
                 .OrderBy(instance => instance.Version)

--- a/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
+++ b/src/LanguageServer.Common/Utilities/MSBuildHelper.cs
@@ -131,9 +131,9 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
         ///     An optional <see cref="ILogger"/> to use for diagnostic purposes (if not specified, the static <see cref="Log.Logger"/> will be used).
         /// </param>
         /// <returns>
-        ///     A <see cref="VisualStudioInstance"/> representing the discovered version of the MSBuild engine, or <c>null</c> if no compatible version was found.
+        ///     A <see cref="MSBuildEngineInstance"/> representing the discovered version of the MSBuild engine, or <c>null</c> if no compatible version was found.
         /// </returns>
-        public static VisualStudioInstance FindMSBuildEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger)
+        public static MSBuildEngineInstance FindMSBuildEngineForTargetFrameworkVersion(Version targetFrameworkVersion, ILogger logger)
         {
             var allInstances = MSBuildLocator.QueryVisualStudioInstances();
 
@@ -161,9 +161,11 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
                     targetFrameworkVersion,
                     String.Join(", ", foundVersions)
                 );
+
+                return null;
             }
 
-            return firstCompatibleInstance;
+            return new MSBuildEngineInstance(Version: firstCompatibleInstance.Version, BaseDirectory: firstCompatibleInstance.MSBuildPath);
         }
 
         /// <summary>
@@ -538,4 +540,33 @@ namespace MSBuildProjectTools.LanguageServer.Utilities
             public static readonly string ProjectAssetsFile = "ProjectAssetsFile";
         }
     }
+
+    /// <summary>
+    ///     Information about an instance of the MSBuild engine.
+    /// </summary>
+    /// <param name="Version">
+    ///     The MSBuild engine version.
+    /// </param>
+    /// <param name="BaseDirectory">
+    ///     The MSBuild engine's base directory.
+    /// </param>
+    public record class MSBuildEngineInstance(Version Version, string BaseDirectory)
+    {
+        /// <summary>
+        ///     Get the full path to the SDK import directory for the specified SDK.
+        /// </summary>
+        /// <param name="sdkName">
+        ///     The name of the target SDK (e.g. "Microsoft.NET.SDK").
+        /// </param>
+        /// <returns>
+        ///     The SDK import directory (e.g. the directory containing "SDK.props" and/or "SDK.targets").
+        /// </returns>
+        public string GetSdkImportDirectory(string sdkName)
+        {
+            if (string.IsNullOrWhiteSpace(sdkName))
+                throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(sdkName)}.", nameof(sdkName));
+
+            return Path.Combine(BaseDirectory, "Sdks", sdkName, "Sdk");
+        }
+    };
 }

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -77,50 +77,84 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         /// </returns>
         async Task<LocationOrLocationLinks> OnDefinition(TextDocumentPositionParams parameters, CancellationToken cancellationToken)
         {
-            ProjectDocument projectDocument = await Workspace.GetProjectDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
+            Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
 
-            using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
+            using (await document.Lock.ReaderLockAsync(cancellationToken))
             {
-                if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
-                    return null;
-
                 Position position = parameters.Position.ToNative();
-                MSBuildObject msbuildObjectAtPosition = projectDocument.GetMSBuildObjectAtPosition(position);
-                if (msbuildObjectAtPosition == null)
-                    return null;
 
-                if (msbuildObjectAtPosition is MSBuildSdkImport sdkImportAtPosition)
+                switch (document)
                 {
-                    // TODO: Parse imported project and determine location of root element (use that range instead).
-                    LocationOrLocationLink[] locations =
-                        sdkImportAtPosition.ImportedProjectRoots.Select(
-                            importedProjectRoot => new LocationOrLocationLink(
-                                new Location
-                                {
-                                    Range = Range.Empty.ToLsp(),
-                                    Uri = VSCodeDocumentUri.FromFileSystemPath(importedProjectRoot.Location.File)
-                                })
-                        )
-                        .ToArray();
+                    case ProjectDocument projectDocument:
+                    {
+                        if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
+                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
-                    return new LocationOrLocationLinks(locations);
-                }
-                else if (msbuildObjectAtPosition is MSBuildImport importAtPosition)
-                {
-                    // TODO: Parse imported project and determine location of root element (use that range instead).
-                    return new LocationOrLocationLinks(
-                        importAtPosition.ImportedProjectRoots.Select(
-                            importedProjectRoot => new LocationOrLocationLink(
-                                new Location
-                                {
-                                    Range = Range.Empty.ToLsp(),
-                                    Uri = VSCodeDocumentUri.FromFileSystemPath(importedProjectRoot.Location.File)
-                                })
-                    ));
+                        MSBuildObject msbuildObjectAtPosition = projectDocument.GetMSBuildObjectAtPosition(position);
+                        if (msbuildObjectAtPosition == null)
+                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+
+                        if (msbuildObjectAtPosition is MSBuildSdkImport sdkImportAtPosition)
+                        {
+                            // TODO: Parse imported project and determine location of root element (use that range instead).
+
+                            LocationOrLocationLink[] locations =
+                                sdkImportAtPosition.ImportedProjectRoots
+                                    .DistinctBy(importedProjectRoot => importedProjectRoot.Location.File)
+                                    .Select(
+                                        importedProjectRoot => new LocationOrLocationLink(
+                                            new Location
+                                            {
+                                                Range = Range.Empty.ToLsp(),
+                                                Uri = VSCodeDocumentUri.FromFileSystemPath(importedProjectRoot.Location.File),
+                                            }
+                                        )
+                                    )
+                                    .ToArray();
+
+                            return new LocationOrLocationLinks(locations);
+                        }
+                        else if (msbuildObjectAtPosition is MSBuildImport importAtPosition)
+                        {
+                            // TODO: Parse imported project and determine location of root element (use that range instead).
+
+                            LocationOrLocationLink[] locations =
+                                importAtPosition.ImportedProjectRoots
+                                    .DistinctBy(importedProjectRoot => importedProjectRoot.Location.File)
+                                    .Select(
+                                        importedProjectRoot => new LocationOrLocationLink(
+                                            new Location
+                                            {
+                                                Range = Range.Empty.ToLsp(),
+                                                Uri = VSCodeDocumentUri.FromFileSystemPath(importedProjectRoot.Location.File),
+                                            }
+                                        )
+                                    )
+                                    .ToArray();
+
+                            return new LocationOrLocationLinks(locations);
+                        }
+
+                        break;
+                    }
+                    case SolutionDocument solutionDocument:
+                    {
+                        if (!solutionDocument.HasSolution || solutionDocument.IsSolutionCached)
+                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+
+                        VsSolutionObject solutionObjectAtPosition = solutionDocument.GetVsSolutionObjectAtPosition(position);
+                        if (solutionObjectAtPosition == null)
+                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+
+
+                        // TODO: Determine which types of solution objects (if  any) we want to support go-to-definition for.
+
+                        break;
+                    }
                 }
             }
 
-            return null;
+            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
         }
 
         /// <summary>

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -88,11 +88,11 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                     case ProjectDocument projectDocument:
                     {
                         if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
-                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+                            return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
                         MSBuildObject msbuildObjectAtPosition = projectDocument.GetMSBuildObjectAtPosition(position);
                         if (msbuildObjectAtPosition == null)
-                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+                            return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
                         if (msbuildObjectAtPosition is MSBuildSdkImport sdkImportAtPosition)
                         {

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -154,7 +154,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 }
             }
 
-            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+            return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
         }
 
         /// <summary>

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -140,11 +140,11 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                     case SolutionDocument solutionDocument:
                     {
                         if (!solutionDocument.HasSolution || solutionDocument.IsSolutionCached)
-                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+                            return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
                         VsSolutionObject solutionObjectAtPosition = solutionDocument.GetVsSolutionObjectAtPosition(position);
                         if (solutionObjectAtPosition == null)
-                            return new LocationOrLocationLinks(); // Due to an OnmiSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
+                            return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
 
                         // TODO: Determine which types of solution objects (if  any) we want to support go-to-definition for.

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -75,6 +75,11 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         /// <returns>
         ///     A <see cref="Task"/> representing the operation whose result is the definition location or <c>null</c> if no definition is provided.
         /// </returns>
+        /// <remarks>
+        ///     Due to an OmniSharp LSP library bug, this method currently has to return an empty <see cref="LocationOrLocationLinks"/> value, rather than <c>null</c> (the version of OmniSharp LSP that we are currently using cannot handle <c>null</c> return values from callers).
+        ///     
+        ///     <para>TODO: fix this when we move to the current version of OmniSharp LSP</para>
+        /// </remarks>
         async Task<LocationOrLocationLinks> OnDefinition(TextDocumentPositionParams parameters, CancellationToken cancellationToken)
         {
             Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);

--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -147,7 +147,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                             return new LocationOrLocationLinks(); // Due to an OmniSharp bug, we must return an empty result rather than null (TODO: fix this when we move to the current version of OmniSharp LSP).
 
 
-                        // TODO: Determine which types of solution objects (if  any) we want to support go-to-definition for.
+                        // TODO: Determine which types of solution objects (if any) we want to support go-to-definition for.
 
                         break;
                     }

--- a/src/LanguageServer.SemanticModel.VsSolutionXml/VsSolutionFile.cs
+++ b/src/LanguageServer.SemanticModel.VsSolutionXml/VsSolutionFile.cs
@@ -2,8 +2,6 @@ using Microsoft.VisualStudio.SolutionPersistence.Model;
 using MSBuildProjectTools.LanguageServer.Utilities;
 using System;
 using System.IO;
-using System.Linq;
-using static NuGet.Packaging.PackagingConstants;
 
 namespace MSBuildProjectTools.LanguageServer.SemanticModel
 {
@@ -13,6 +11,21 @@ namespace MSBuildProjectTools.LanguageServer.SemanticModel
     public class VsSolutionFile
         : VsSolutionObject<SolutionFolderModel>
     {
+        /// <summary>
+        ///     Create a new <see cref="VsSolutionFile"/>.
+        /// </summary>
+        /// <param name="solution">
+        ///     The <see cref="VsSolution"/> that contains the underlying object.
+        /// </param>
+        /// <param name="folder">
+        ///     The underlying <see cref="SolutionFolderModel"/> containing the file represented by the <see cref="VsSolutionFile"/>.
+        /// </param>
+        /// <param name="relativePath">
+        ///     The path of the file, relative to the parent folder.
+        /// </param>
+        /// <param name="declaringXml">
+        ///     An <see cref="XSNode"/> representing the object's declaring XML.
+        /// </param>
         public VsSolutionFile(VsSolution solution, SolutionFolderModel folder, string relativePath, XSNode declaringXml)
             : base(solution, folder, declaringXml)
         {

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -157,7 +157,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             </Project>
             """);
 
-            VisualStudioInstance compatibleMSBuild = MSBuildHelper.FindMSBuildEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
+            MSBuildEngineInstance compatibleMSBuild = MSBuildHelper.FindMSBuildEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
             Assert.NotNull(compatibleMSBuild);
 
             var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -178,10 +178,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     {
                         Uri = DocumentUri.FromFileSystemPath(
                             Path.Combine(
-                                compatibleMSBuild.MSBuildPath,
-                                "Sdks",
-                                "Microsoft.NET.SDK",
-                                "Sdk",
+                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.SDK"),
                                 "Sdk.props"
                             )
                         ),
@@ -196,10 +193,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     {
                         Uri = DocumentUri.FromFileSystemPath(
                             Path.Combine(
-                                compatibleMSBuild.MSBuildPath,
-                                "Sdks",
-                                "Microsoft.NET.SDK",
-                                "Sdk",
+                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.SDK"),
                                 "Sdk.targets"
                             )
                         ),

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Build.Locator;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -178,7 +178,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     {
                         Uri = DocumentUri.FromFileSystemPath(
                             Path.Combine(
-                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.SDK"),
+                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.Sdk"),
                                 "Sdk.props"
                             )
                         ),
@@ -193,7 +193,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     {
                         Uri = DocumentUri.FromFileSystemPath(
                             Path.Combine(
-                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.SDK"),
+                                compatibleMSBuild.GetSdkImportDirectory("Microsoft.NET.Sdk"),
                                 "Sdk.targets"
                             )
                         ),

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -157,7 +157,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             </Project>
             """);
 
-            MSBuildEngineInstance compatibleMSBuild = MSBuildHelper.FindMSBuildEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
+            MSBuildEngineInstance compatibleMSBuild = MSBuildHelper.FindEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
             Assert.NotNull(compatibleMSBuild);
 
             var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -167,7 +167,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                 {
                     Uri = DocumentUri.FromFileSystemPath(testFilePath)
                 },
-                Position = new Position(1, 14).ToLsp()
+                Position = new Position(1, 15).ToLsp()
             }, timeout.Token);
 
             Assert.NotNull(definitionResult);

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Build.Locator;
+using Newtonsoft.Json;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -139,6 +141,85 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                 "Property: `OutputType` Type of output to generate (WinExe, Exe, or Library) Value: `Exe`",
                 hoverResult.Contents.ToString()
             );
+        }
+
+        [Fact]
+        public async Task DefinitionCsproj()
+        {
+            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>  
+            </Project>
+            """);
+
+            VisualStudioInstance compatibleMSBuild = MSBuildHelper.FindMSBuildEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
+            Assert.NotNull(compatibleMSBuild);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            LocationOrLocationLinks definitionResult = await _fixture.Client.SendRequest(new DefinitionParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath)
+                },
+                Position = new Position(1, 14).ToLsp()
+            }, timeout.Token);
+
+            Assert.NotNull(definitionResult);
+
+            LocationOrLocationLink[] expectedDefinitions = [
+                new LocationOrLocationLink(
+                    new Location
+                    {
+                        Uri = DocumentUri.FromFileSystemPath(
+                            Path.Combine(
+                                compatibleMSBuild.MSBuildPath,
+                                "Sdks",
+                                "Microsoft.NET.SDK",
+                                "Sdk",
+                                "Sdk.props"
+                            )
+                        ),
+                        Range = new Range(
+                            start: new Position(1, 1),
+                            end: new Position(1, 1)
+                        ).ToLsp()
+                    }
+                ),
+                new LocationOrLocationLink(
+                    new Location
+                    {
+                        Uri = DocumentUri.FromFileSystemPath(
+                            Path.Combine(
+                                compatibleMSBuild.MSBuildPath,
+                                "Sdks",
+                                "Microsoft.NET.SDK",
+                                "Sdk",
+                                "Sdk.targets"
+                            )
+                        ),
+                        Range = new Range(
+                            start: new Position(1, 1),
+                            end: new Position(1, 1)
+                        ).ToLsp()
+                    }
+                ),
+            ];
+            Log.Information("Expected definitions: {DefinitionJson:l}",
+                JsonConvert.SerializeObject(expectedDefinitions, Formatting.Indented)
+            );
+
+            LocationOrLocationLink[] actualDefinitions = definitionResult.ToArray();
+            Log.Information("Actual definitions: {DefinitionJson:l}",
+                JsonConvert.SerializeObject(actualDefinitions, Formatting.Indented)
+            );
+            
+            Assert.Equal(expectedDefinitions, actualDefinitions);
         }
 
         [Fact]

--- a/test/LanguageServer.IntegrationTests/LanguageServerFixture.cs
+++ b/test/LanguageServer.IntegrationTests/LanguageServerFixture.cs
@@ -24,14 +24,16 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
     /// <summary>
     /// Fixture for managing the language server process and client connection.
     /// </summary>
-    public class LanguageServerFixture(bool dynamicRegistration = true) : IAsyncDisposable
+    public class LanguageServerFixture : IAsyncDisposable
     {
         const string ServerDllName = "MSBuildProjectTools.LanguageServer.Host.dll";
+
+        static readonly Assembly ThisAssembly = typeof(LanguageServerFixture).Assembly;
 
         /// <summary>
         ///  Controls dynamic registration support of the language client.
         /// </summary>
-        readonly bool _dynamicRegistration = dynamicRegistration;
+        readonly bool _dynamicRegistration;
 
         /// <summary>
         /// The logger.
@@ -57,6 +59,34 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
         /// The language client.
         /// </summary>
         ILanguageClient _client;
+
+        public LanguageServerFixture(bool dynamicRegistration = true)
+        {
+            _dynamicRegistration = dynamicRegistration;
+
+            TargetFrameworkName = ThisAssembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+            TargetFrameworkVersion = new Version(0, 0, 0);
+
+            if (TargetFrameworkName == null)
+                return;
+
+            const string versionPrefix = "Version=v";
+
+            string[] targetFrameworkNameComponents = TargetFrameworkName.Split(',');
+            string targetFrameworkVersionComponent = targetFrameworkNameComponents.FirstOrDefault(
+                component => component.StartsWith(versionPrefix)
+            );
+            if (targetFrameworkVersionComponent == null)
+                return;
+
+            targetFrameworkVersionComponent = targetFrameworkVersionComponent.Substring(versionPrefix.Length);
+            if (Version.TryParse(targetFrameworkVersionComponent, out Version targetFrameworkVersion))
+                TargetFrameworkVersion = targetFrameworkVersion;
+        }
+
+        public string TargetFrameworkName { get; }
+
+        public Version TargetFrameworkVersion { get; }
 
         /// <summary>
         /// The language client.


### PR DESCRIPTION
This is part of the outstanding work from PR #136 (which was getting a little too large for comfort).  I've broken the remaining work up into more-manageable chunks.

I have also  extended the language-server fixture to support discovery of matching .NET SDK versions for integration-test scenarios.

#140