### PR TITLE
Use Workspace.GetDocument instead of Workspace.GetProjectDocument in DocumentSymbolHandler

### DIFF
--- a/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DefinitionHandler.cs
@@ -76,7 +76,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         ///     A <see cref="Task"/> representing the operation whose result is the definition location or <c>null</c> if no definition is provided.
         /// </returns>
         /// <remarks>
-        ///     Due to an OmniSharp LSP library bug, this method currently has to return an empty <see cref="LocationOrLocationLinks"/> value, rather than <c>null</c> (the version of OmniSharp LSP that we are currently using cannot handle <c>null</c> return values from callers).
+        ///     Due to an OmniSharp LSP library bug, this method currently has to return an empty <see cref="LocationOrLocationLinks"/> value, rather than <c>null</c> (the version of OmniSharp LSP that we are currently using cannot correctly deal with <c>null</c> return values from handlers).
         ///     
         ///     <para>TODO: fix this when we move to the current version of OmniSharp LSP</para>
         /// </remarks>

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -106,7 +106,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                                 {
                                     string trimmedInclude = string.Join(";",
                                         include.Split(
-                                            separator: [';'],
+                                            separator: new char[] { ';' },
                                             options: StringSplitOptions.RemoveEmptyEntries
                                         )
                                         .Select(includedItem => includedItem.Trim())

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -65,7 +65,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         }
 
         /// <summary>
-        ///     Called when completions are requested.
+        ///     Called when document symbol are requested.
         /// </summary>
         /// <param name="parameters">
         ///     The request parameters.
@@ -74,89 +74,104 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         ///     A <see cref="CancellationToken"/> that can be used to cancel the request.
         /// </param>
         /// <returns>
-        ///     A <see cref="Task"/> representing the operation whose result is the completion list or <c>null</c> if no completions are provided.
+        ///     A <see cref="Task"/> representing the operation whose result is the document symbol container, or <c>null</c> if no completions are provided.
         /// </returns>
+        /// <remarks>
+        ///     Due to an OmniSharp LSP library bug, this method currently has to return an empty <see cref="SymbolInformationOrDocumentSymbolContainer"/> value, rather than <c>null</c> (the version of OmniSharp LSP that we are currently using cannot correctly deal with <c>null</c> return values from handlers).
+        ///     
+        ///     <para>TODO: fix this when we move to the current version of OmniSharp LSP</para>
+        /// </remarks>
         async Task<SymbolInformationOrDocumentSymbolContainer> OnDocumentSymbols(DocumentSymbolParams parameters, CancellationToken cancellationToken)
         {
-            ProjectDocument projectDocument = await Workspace.GetProjectDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
+
+            Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
 
             var symbols = new List<SymbolInformationOrDocumentSymbol>();
-            using (await projectDocument.Lock.ReaderLockAsync(cancellationToken))
+            using (await document.Lock.ReaderLockAsync(cancellationToken))
             {
-                // We need a valid MSBuild project with up-to-date positional information.
-                if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
-                    return null;
-
-                foreach (MSBuildObject msbuildObject in projectDocument.MSBuildObjects)
+                switch (document)
                 {
-                    // Special case for item groups, which can contribute multiple symbols from a single item group.
-                    if (msbuildObject is MSBuildItemGroup itemGroup)
+                    case ProjectDocument projectDocument:
                     {
-                        symbols.AddRange(itemGroup.Includes.Select(include =>
+                        // We need a valid MSBuild project with up-to-date positional information.
+                        if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
+                            return null;
+
+                        foreach (MSBuildObject msbuildObject in projectDocument.MSBuildObjects)
                         {
-                            string trimmedInclude = string.Join(";",
-                                include.Split(
-                                    new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries
-                                )
-                                .Select(includedItem => includedItem.Trim())
-                            );
-
-
-                            return new SymbolInformationOrDocumentSymbol(
-                                new SymbolInformation
+                            // Special case for item groups, which can contribute multiple symbols from a single item group.
+                            if (msbuildObject is MSBuildItemGroup itemGroup)
+                            {
+                                symbols.AddRange(itemGroup.Includes.Select(include =>
                                 {
-                                    Name = $"{itemGroup.Name} ({trimmedInclude})",
-                                    Kind = SymbolKind.Array,
-                                    ContainerName = "Item",
-                                    Location = new Location
-                                    {
-                                        Uri = projectDocument.DocumentUri,
-                                        Range = msbuildObject.XmlRange.ToLsp()
-                                    }
-                                });
-                        }));
+                                    string trimmedInclude = string.Join(";",
+                                        include.Split(
+                                            separator: [';'],
+                                            options: StringSplitOptions.RemoveEmptyEntries
+                                        )
+                                        .Select(includedItem => includedItem.Trim())
+                                    );
 
-                        continue;
-                    }
 
-                    var symbol = new SymbolInformation
-                    {
-                        Name = msbuildObject.Name,
-                        Location = new Location
-                        {
-                            Uri = projectDocument.DocumentUri,
-                            Range = msbuildObject.XmlRange.ToLsp()
+                                    return new SymbolInformationOrDocumentSymbol(
+                                        new SymbolInformation
+                                        {
+                                            Name = $"{itemGroup.Name} ({trimmedInclude})",
+                                            Kind = SymbolKind.Array,
+                                            ContainerName = "Item",
+                                            Location = new Location
+                                            {
+                                                Uri = projectDocument.DocumentUri,
+                                                Range = msbuildObject.XmlRange.ToLsp()
+                                            }
+                                        });
+                                }));
+
+                                continue;
+                            }
+
+                            var symbol = new SymbolInformation
+                            {
+                                Name = msbuildObject.Name,
+                                Location = new Location
+                                {
+                                    Uri = projectDocument.DocumentUri,
+                                    Range = msbuildObject.XmlRange.ToLsp()
+                                }
+                            };
+                            if (msbuildObject is MSBuildTarget)
+                            {
+                                symbol.ContainerName = "Target";
+                                symbol.Kind = SymbolKind.Function;
+                            }
+                            else if (msbuildObject is MSBuildProperty)
+                            {
+                                symbol.ContainerName = "Property";
+                                symbol.Kind = SymbolKind.Property;
+                            }
+                            else if (msbuildObject is MSBuildImport)
+                            {
+                                symbol.ContainerName = "Import";
+                                symbol.Kind = SymbolKind.Package;
+                            }
+                            else if (msbuildObject is MSBuildSdkImport)
+                            {
+                                symbol.ContainerName = "Import (SDK)";
+                                symbol.Kind = SymbolKind.Package;
+                            }
+                            else
+                                continue;
+
+                            symbols.Add(symbol);
                         }
-                    };
-                    if (msbuildObject is MSBuildTarget)
-                    {
-                        symbol.ContainerName = "Target";
-                        symbol.Kind = SymbolKind.Function;
-                    }
-                    else if (msbuildObject is MSBuildProperty)
-                    {
-                        symbol.ContainerName = "Property";
-                        symbol.Kind = SymbolKind.Property;
-                    }
-                    else if (msbuildObject is MSBuildImport)
-                    {
-                        symbol.ContainerName = "Import";
-                        symbol.Kind = SymbolKind.Package;
-                    }
-                    else if (msbuildObject is MSBuildSdkImport)
-                    {
-                        symbol.ContainerName = "Import (SDK)";
-                        symbol.Kind = SymbolKind.Package;
-                    }
-                    else
-                        continue;
 
-                    symbols.Add(symbol);
+                        break;
+                    }
                 }
             }
 
             if (symbols.Count == 0)
-                return null;
+                return new SymbolInformationOrDocumentSymbolContainer();
 
             return new SymbolInformationOrDocumentSymbolContainer(
                 symbols.OrderBy(symbol => symbol.SymbolInformation.Name)

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -112,7 +112,6 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                                         .Select(includedItem => includedItem.Trim())
                                     );
 
-
                                     return new SymbolInformationOrDocumentSymbol(
                                         new SymbolInformation
                                         {

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -95,7 +95,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                     {
                         // We need a valid MSBuild project with up-to-date positional information.
                         if (!projectDocument.HasMSBuildProject || projectDocument.IsMSBuildProjectCached)
-                            return null;
+                            return new SymbolInformationOrDocumentSymbolContainer();
 
                         foreach (MSBuildObject msbuildObject in projectDocument.MSBuildObjects)
                         {

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -15,10 +15,21 @@ using Xunit.Abstractions;
 namespace MSBuildProjectTools.LanguageServer.IntegrationTests
 {
     using CustomProtocol;
+    using Newtonsoft.Json.Converters;
+    using System.Xml.Linq;
     using Utilities;
 
     public class BasicIntegrationTests(ITestOutputHelper testOutput) : IntegrationTestBase(testOutput), IAsyncLifetime
     {
+        static readonly JsonSerializerSettings DumpSerializerSettings = new JsonSerializerSettings
+        {
+            Converters =
+            {
+                new StringEnumConverter(),
+            },
+            Formatting = Formatting.Indented,
+        };
+
         private readonly LanguageServerFixture _fixture = new(false);
         private readonly TempDirectory _workspaceRoot = new();
 
@@ -87,7 +98,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             Assert.NotNull(completionList.Items);
 
             CompletionItem[] completionItems = completionList.Items.OrderBy(item => item.SortText ?? item.Label).ToArray();
-            
+
             Log.Information("Received {CompletionCount} completions from the language server.", completionItems.Length);
             for (int itemIndex = 0; itemIndex < completionItems.Length; itemIndex++)
             {
@@ -204,15 +215,148 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                 ),
             ];
             Log.Information("Expected definitions: {DefinitionJson:l}",
-                JsonConvert.SerializeObject(expectedDefinitions, Formatting.Indented)
+                JsonConvert.SerializeObject(expectedDefinitions, DumpSerializerSettings)
             );
 
             LocationOrLocationLink[] actualDefinitions = definitionResult.ToArray();
             Log.Information("Actual definitions: {DefinitionJson:l}",
-                JsonConvert.SerializeObject(actualDefinitions, Formatting.Indented)
+                JsonConvert.SerializeObject(actualDefinitions, DumpSerializerSettings)
             );
-            
+
             Assert.Equal(expectedDefinitions, actualDefinitions);
+        }
+
+        [Fact]
+        public async Task SymbolsCsproj()
+        {
+            var testFilePath = Path.Combine(
+                Path.GetFullPath(_workspaceRoot),
+                "Test.csproj"
+            );
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>  
+            </Project>
+            """);
+
+            MSBuildEngineInstance compatibleMSBuild = MSBuildHelper.FindEngineForTargetFrameworkVersion(_fixture.TargetFrameworkVersion, logger: Log);
+            Assert.NotNull(compatibleMSBuild);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            SymbolInformationOrDocumentSymbolContainer documentSymbolResult = await _fixture.Client.SendRequest(new DocumentSymbolParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                },
+            }, timeout.Token);
+
+            Assert.NotNull(documentSymbolResult);
+
+            SymbolInformation[] expectedSymbols = [
+                new SymbolInformation
+                {
+                    Name = "Microsoft.NET.Sdk",
+                    ContainerName = "Import (SDK)",
+                    Kind = SymbolKind.Package,
+                    Location = new Location
+                    {
+                        Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                        Range = new Range(
+                            start: new Position(1, 10),
+                            end: new Position(1, 33)
+                        ).ToLsp(),
+                    },
+                },
+                new SymbolInformation
+                {
+                    Name = "OutputType",
+                    ContainerName = "Property",
+                    Kind = SymbolKind.Property,
+                    Location = new Location
+                    {
+                        Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                        Range = new Range(
+                            start: new Position(3, 9),
+                            end: new Position(3, 37)
+                        ).ToLsp(),
+                    },
+                },
+                new SymbolInformation
+                {
+                    Name = "TargetFramework",
+                    ContainerName = "Property",
+                    Kind = SymbolKind.Property,
+                    Location = new Location
+                    {
+                        Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                        Range = new Range(
+                            start: new Position(4, 9),
+                            end: new Position(4, 50)
+                        ).ToLsp(),
+                    },
+                },
+            ];
+            Log.Information("Expected symbols: {SymbolJson:l}",
+                JsonConvert.SerializeObject(expectedSymbols, DumpSerializerSettings)
+            );
+
+            SymbolInformation[] actualSymbols = documentSymbolResult.Select(symbol => symbol.SymbolInformation).ToArray();
+            Log.Information("Actual symbols: {SymbolJson:l}",
+                JsonConvert.SerializeObject(actualSymbols, DumpSerializerSettings)
+            );
+
+            Assert.Collection(actualSymbols,
+                symbol01 =>
+                {
+                    Assert.Equal("Microsoft.NET.Sdk", symbol01.Name);
+                    Assert.Equal(SymbolKind.Package, symbol01.Kind);
+                    Assert.Equal("Import (SDK)", symbol01.ContainerName);
+
+                    Assert.Equal(testFilePath, symbol01.Location.Uri.GetFileSystemPath(), ignoreCase: true);
+                    Assert.Equal(
+                        new Range(
+                            start: new Position(1, 10),
+                            end: new Position(1, 33)
+                        ),
+                        symbol01.Location.Range.ToNative()
+                    );
+                },
+                symbol02 =>
+                {
+                    Assert.Equal("OutputType", symbol02.Name);
+                    Assert.Equal(SymbolKind.Property, symbol02.Kind);
+                    Assert.Equal("Property", symbol02.ContainerName);
+
+                    Assert.Equal(testFilePath, symbol02.Location.Uri.GetFileSystemPath(), ignoreCase: true);
+                    Assert.Equal(
+                        new Range(
+                            start: new Position(3, 9),
+                            end: new Position(3, 37)
+                        ),
+                        symbol02.Location.Range.ToNative()
+                    );
+                },
+                symbol03 =>
+                {
+                    Assert.Equal("TargetFramework", symbol03.Name);
+                    Assert.Equal(SymbolKind.Property, symbol03.Kind);
+                    Assert.Equal("Property", symbol03.ContainerName);
+
+                    Assert.Equal(testFilePath, symbol03.Location.Uri.GetFileSystemPath(), ignoreCase: true);
+                    Assert.Equal(
+                        new Range(
+                            start: new Position(4, 9),
+                            end: new Position(4, 50)
+                        ),
+                        symbol03.Location.Range.ToNative()
+                    );
+                }
+            );
         }
 
         [Fact]

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -16,7 +16,6 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
 {
     using CustomProtocol;
     using Newtonsoft.Json.Converters;
-    using System.Xml.Linq;
     using Utilities;
 
     public class BasicIntegrationTests(ITestOutputHelper testOutput) : IntegrationTestBase(testOutput), IAsyncLifetime


### PR DESCRIPTION
Also, add integration test for document symbol handler (currently MSBuild-only).

tintoy/msbuild-project-tools-server#139