### PR TITLE
Use Workspace.GetDocument instead of Workspace.GetProjectDocument in DocumentSyncHandler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,5 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
-    <!--
-      Disable MSBuild reference check (not applicable to our scenario; see https://github.com/microsoft/MSBuildLocator/blob/55ff263d5a99f91a215c9ca5fbba8ccfa3371fe5/docs/diagnostics/MSBL001.md for details).
-    -->
-    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 </Project>

--- a/src/LanguageServer.Common/LanguageServer.Common.csproj
+++ b/src/LanguageServer.Common/LanguageServer.Common.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Serilog" />
   </ItemGroup>

--- a/src/LanguageServer.Engine/ContentProviders/HoverContentProvider.cs
+++ b/src/LanguageServer.Engine/ContentProviders/HoverContentProvider.cs
@@ -177,7 +177,7 @@ namespace MSBuildProjectTools.LanguageServer.ContentProviders
                 {
                     return new Container<MarkedString>(
                         $"NuGet Package: {itemGroup.FirstInclude}",
-                        $"Requested Version: {packageRequestedVersion}`",
+                        $"Requested Version: `{packageRequestedVersion}`",
                         "State: Not restored"
                     );
                 }

--- a/src/LanguageServer.Engine/Documents/SolutionDocument.cs
+++ b/src/LanguageServer.Engine/Documents/SolutionDocument.cs
@@ -6,6 +6,7 @@ using MSBuildProjectTools.LanguageServer.Utilities;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
@@ -69,6 +70,26 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         ///     The solution object-lookup facility.
         /// </summary>
         protected VsSolutionObjectLocator? SolutionLocator { get; private set; }
+
+        /// <summary>
+        ///     Solution objects in the project that correspond to locations in the file.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     The solution is cached or not loaded.
+        /// </exception>
+        public IEnumerable<VsSolutionObject> SolutionObjects
+        {
+            get
+            {
+                if (!HasSolution)
+                    throw new InvalidOperationException($"MSBuild project '{SolutionFile.FullName}' is not loaded.");
+
+                if (IsSolutionCached)
+                    throw new InvalidOperationException($"MSBuild project '{SolutionFile.FullName}' is a cached (out-of-date) copy because the solution XML is currently invalid; positional lookups can't work in this scenario.");
+
+                return SolutionLocator.AllObjects;
+            }
+        }
 
         /// <summary>
         ///     Is the underlying solution cached (i.e. out-of-date with respect to the source text)?

--- a/src/LanguageServer.Engine/Documents/SolutionDocument.cs
+++ b/src/LanguageServer.Engine/Documents/SolutionDocument.cs
@@ -72,7 +72,7 @@ namespace MSBuildProjectTools.LanguageServer.Documents
         protected VsSolutionObjectLocator? SolutionLocator { get; private set; }
 
         /// <summary>
-        ///     Solution objects in the project that correspond to locations in the file.
+        ///     Solution objects in the solution that correspond to locations in the file.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///     The solution is cached or not loaded.

--- a/src/LanguageServer.Engine/Documents/SolutionDocument.cs
+++ b/src/LanguageServer.Engine/Documents/SolutionDocument.cs
@@ -82,10 +82,10 @@ namespace MSBuildProjectTools.LanguageServer.Documents
             get
             {
                 if (!HasSolution)
-                    throw new InvalidOperationException($"MSBuild project '{SolutionFile.FullName}' is not loaded.");
+                    throw new InvalidOperationException($"Solution '{SolutionFile.FullName}' is not loaded.");
 
                 if (IsSolutionCached)
-                    throw new InvalidOperationException($"MSBuild project '{SolutionFile.FullName}' is a cached (out-of-date) copy because the solution XML is currently invalid; positional lookups can't work in this scenario.");
+                    throw new InvalidOperationException($"Solution '{SolutionFile.FullName}' is a cached (out-of-date) copy because the solution XML is currently invalid; positional lookups can't work in this scenario.");
 
                 return SolutionLocator.AllObjects;
             }

--- a/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSymbolHandler.cs
@@ -83,7 +83,6 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         /// </remarks>
         async Task<SymbolInformationOrDocumentSymbolContainer> OnDocumentSymbols(DocumentSymbolParams parameters, CancellationToken cancellationToken)
         {
-
             Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
 
             var symbols = new List<SymbolInformationOrDocumentSymbol>();

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using NuGet.Configuration;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -11,16 +12,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MSBuildProjectTools.LanguageServer.Handlers
 {
-    using System.Threading;
     using CustomProtocol;
     using Documents;
-    using MediatR;
     using SemanticModel;
-    using Utilities;
 
     /// <summary>
     ///     The handler for language server document synchronization.
@@ -124,86 +123,95 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         /// </returns>
         async Task OnDidOpenTextDocument(DidOpenTextDocumentParams parameters, CancellationToken cancellationToken)
         {
-            Server.NotifyBusy("Loading project...");
+            Server.NotifyBusy("Loading...");
 
-            ProjectDocument projectDocument = await Workspace.GetProjectDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
-            Workspace.PublishDiagnostics(projectDocument);
+            Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
+            Workspace.PublishDiagnostics(document);
 
-            // Only enable expression-related language service facilities if they're using our custom "MSBuild" language type (rather than "XML").
-            projectDocument.EnableExpressions = parameters.TextDocument.LanguageId == "msbuild";
-
-            Server.ClearBusy("Project loaded.");
-
-            if (!projectDocument.HasXml)
+            switch (document)
             {
-                Log.Warning("Failed to load project file {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
-
-                return;
-            }
-
-            switch (projectDocument)
-            {
-                case MasterProjectDocument masterProjectDocument:
+                case ProjectDocument projectDocument:
                 {
-                    if (masterProjectDocument.HasMSBuildProject)
-                        Log.Information("Successfully loaded project {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
+                    // Only enable expression-related language service facilities if they're using our custom "MSBuild" language type (rather than "XML").
+                    projectDocument.EnableExpressions = parameters.TextDocument.LanguageId == "msbuild";
 
-                    break;
-                }
-                case SubProjectDocument subProjectDocument:
-                {
-                    if (subProjectDocument.HasMSBuildProject)
+                    if (!projectDocument.HasXml)
                     {
-                        Log.Information("Successfully loaded project {ProjectFilePath} as a sub-project of {MasterProjectFileName}.",
-                            projectDocument.ProjectFile.FullName,
-                            subProjectDocument.MasterProjectDocument.ProjectFile.Name
-                        );
+                        Log.Warning("Failed to load project file {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
+                        
+                        Server.ClearBusy($"Failed to load project file {projectDocument.ProjectFile.FullName}.");
+
+                        return;
                     }
 
-                    break;
-                }
-            }
+                    Server.ClearBusy("Project loaded.");
 
-            if (Log.IsEnabled(LogEventLevel.Verbose))
-            {
-                Log.Verbose("===========================");
-                foreach (PackageSource packageSource in projectDocument.ConfiguredPackageSources)
-                {
-                    Log.Verbose(" - Project uses package source {PackageSourceName} ({PackageSourceUrl})",
-                        packageSource.Name,
-                        packageSource.Source
-                    );
-                }
-
-                Log.Verbose("===========================");
-                if (projectDocument.HasMSBuildProject)
-                {
-                    Log.Verbose("Scanning task definitions for project {ProjectName}...", projectDocument.ProjectFile.Name);
-                    List<MSBuildTaskAssemblyMetadata> taskAssemblies = projectDocument.GetMSBuildProjectTaskAssemblies();
-                    Log.Verbose("Scan complete for task definitions of project {ProjectName} ({AssemblyCount} assemblies scanned).", projectDocument.ProjectFile.Name, taskAssemblies.Count);
-
-                    Log.Verbose("===========================");
-
-                    if (!projectDocument.IsMSBuildProjectCached)
+                    switch (projectDocument)
                     {
-                        MSBuildObject[] msbuildObjects = projectDocument.MSBuildObjects.ToArray();
-                        Log.Verbose("MSBuild project loaded ({MSBuildObjectCount} MSBuild objects).", msbuildObjects.Length);
-
-                        foreach (MSBuildObject msbuildObject in msbuildObjects)
+                        case MasterProjectDocument masterProjectDocument:
                         {
-                            Log.Verbose("{Type:l}: {Kind} {Name} spanning {XmlRange}",
-                                msbuildObject.GetType().Name,
-                                msbuildObject.Kind,
-                                msbuildObject.Name,
-                                msbuildObject.XmlRange
-                            );
+                            if (masterProjectDocument.HasMSBuildProject)
+                                Log.Information("Successfully loaded project {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
+
+                            break;
+                        }
+                        case SubProjectDocument subProjectDocument:
+                        {
+                            if (subProjectDocument.HasMSBuildProject)
+                            {
+                                Log.Information("Successfully loaded project {ProjectFilePath} as a sub-project of {MasterProjectFileName}.",
+                                    projectDocument.ProjectFile.FullName,
+                                    subProjectDocument.MasterProjectDocument.ProjectFile.Name
+                                );
+                            }
+
+                            break;
                         }
                     }
-                    else
-                        Log.Verbose("MSBuild project not loaded; will used cached project state (as long as positional lookups are not required).");
+
+                    if (Log.IsEnabled(LogEventLevel.Verbose))
+                    {
+                        Log.Verbose("===========================");
+
+                        foreach (PackageSource packageSource in projectDocument.ConfiguredPackageSources)
+                        {
+                            Log.Verbose(" - Project uses package source {PackageSourceName} ({PackageSourceUrl})",
+                                packageSource.Name,
+                                packageSource.Source
+                            );
+                        }
+
+                        if (projectDocument.HasMSBuildProject)
+                        {
+                            Log.Verbose("===========================");
+
+                            Log.Verbose("Scanning task definitions for project {ProjectName}...", projectDocument.ProjectFile.Name);
+                            List<MSBuildTaskAssemblyMetadata> taskAssemblies = projectDocument.GetMSBuildProjectTaskAssemblies();
+                            Log.Verbose("Scan complete for task definitions of project {ProjectName} ({AssemblyCount} assemblies scanned).", projectDocument.ProjectFile.Name, taskAssemblies.Count);
+                        }
+
+                        LogLoadedDocumentState(projectDocument);
+                    }
+
+                    break;
                 }
-                else
-                    Log.Verbose("MSBuild project not loaded.");
+                case SolutionDocument solutionDocument:
+                {
+                    if (!solutionDocument.HasXml)
+                    {
+                        Log.Warning("Failed to load solution file {ProjectFilePath}.", solutionDocument.SolutionFile.FullName);
+                        
+                        Server.ClearBusy($"Failed to load solution file {solutionDocument.SolutionFile.FullName}.");
+
+                        return;
+                    }
+                    
+                    Server.ClearBusy("Solution loaded.");
+
+                    LogLoadedDocumentState(solutionDocument);
+
+                    break;
+                }
             }
         }
 
@@ -230,35 +238,10 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 return;
 
             string updatedDocumentText = mostRecentChange.Text;
-            ProjectDocument projectDocument = await Workspace.TryUpdateProjectDocument(parameters.TextDocument.Uri, updatedDocumentText, cancellationToken);
-            Workspace.PublishDiagnostics(projectDocument);
+            Document document = await Workspace.TryUpdateDocument(parameters.TextDocument.Uri, updatedDocumentText, cancellationToken);
+            Workspace.PublishDiagnostics(document);
 
-            if (Log.IsEnabled(LogEventLevel.Verbose))
-            {
-                Log.Verbose("===========================");
-                if (projectDocument.HasMSBuildProject)
-                {
-                    if (!projectDocument.IsMSBuildProjectCached)
-                    {
-                        MSBuildObject[] msbuildObjects = projectDocument.MSBuildObjects.ToArray();
-                        Log.Verbose("MSBuild project loaded ({MSBuildObjectCount} MSBuild objects).", msbuildObjects.Length);
-
-                        foreach (MSBuildObject msbuildObject in msbuildObjects)
-                        {
-                            Log.Verbose("{Type:l}: {Kind} {Name} spanning {XmlRange}",
-                                msbuildObject.GetType().Name,
-                                msbuildObject.Kind,
-                                msbuildObject.Name,
-                                msbuildObject.XmlRange
-                            );
-                        }
-                    }
-                    else
-                        Log.Verbose("MSBuild project not loaded; will used cached project state (as long as positional lookups are not required).");
-                }
-                else
-                    Log.Verbose("MSBuild project not loaded.");
-            }
+            LogLoadedDocumentState(document);
         }
 
         /// <summary>
@@ -279,24 +262,52 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 DocumentUri.GetFileSystemPath(parameters.TextDocument.Uri)
             );
 
-            ProjectDocument projectDocument = await Workspace.GetProjectDocument(parameters.TextDocument.Uri, reload: true, cancellationToken: cancellationToken);
-            Workspace.PublishDiagnostics(projectDocument);
+            Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, reload: true, cancellationToken: cancellationToken);
+            Workspace.PublishDiagnostics(document);
 
-            if (!projectDocument.HasXml)
+            switch (document)
             {
-                Log.Warning("Failed to reload project file {ProjectFilePath} (XML is invalid).", projectDocument.ProjectFile.FullName);
+                case ProjectDocument projectDocument:
+                {
+                    if (!projectDocument.HasXml)
+                    {
+                        Log.Warning("Failed to reload project file {ProjectFilePath} (XML is invalid).", projectDocument.ProjectFile.FullName);
 
-                return;
+                        return;
+                    }
+
+                    if (!projectDocument.HasMSBuildProject)
+                    {
+                        Log.Warning("Reloaded project file {ProjectFilePath} (XML is valid, but MSBuild project is not).", projectDocument.ProjectFile.FullName);
+
+                        return;
+                    }
+
+                    Log.Information("Successfully reloaded project {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
+
+                    break;
+                }
+                case SolutionDocument solutionDocument:
+                {
+                    if (!solutionDocument.HasXml)
+                    {
+                        Log.Warning("Failed to reload project file {ProjectFilePath} (XML is invalid).", solutionDocument.SolutionFile.FullName);
+
+                        return;
+                    }
+
+                    if (!solutionDocument.HasSolution)
+                    {
+                        Log.Warning("Reloaded project file {ProjectFilePath} (XML is valid, but VS Solution model is not).", solutionDocument.SolutionFile.FullName);
+
+                        return;
+                    }
+
+                    Log.Information("Successfully reloaded project {ProjectFilePath}.", solutionDocument.SolutionFile.FullName);
+
+                    break;
+                }
             }
-
-            if (!projectDocument.HasMSBuildProject)
-            {
-                Log.Warning("Reloaded project file {ProjectFilePath} (XML is valid, but MSBuild project is not).", projectDocument.ProjectFile.FullName);
-
-                return;
-            }
-
-            Log.Information("Successfully reloaded project {ProjectFilePath}.", projectDocument.ProjectFile.FullName);
         }
 
         /// <summary>
@@ -370,6 +381,77 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
             //var textEdits = new List<TextEdit>();
             //return new TextEditContainer(textEdits);
             return Task.FromResult<TextEditContainer>(null);
+        }
+
+        void LogLoadedDocumentState(Document document)
+        {
+            if (document == null)
+                throw new ArgumentNullException(nameof(document));
+
+            if (!Log.IsEnabled(LogEventLevel.Verbose))
+                return;
+
+            Log.Verbose("===========================");
+
+            switch (document)
+            {
+                case ProjectDocument projectDocument:
+                {
+                    Log.Verbose("===========================");
+
+                    if (projectDocument.HasMSBuildProject)
+                    {
+                        if (!projectDocument.IsMSBuildProjectCached)
+                        {
+                            MSBuildObject[] msbuildObjects = projectDocument.MSBuildObjects.ToArray();
+                            Log.Verbose("MSBuild project loaded ({MSBuildObjectCount} MSBuild objects).", msbuildObjects.Length);
+
+                            foreach (MSBuildObject msbuildObject in msbuildObjects)
+                            {
+                                Log.Verbose("{Type:l}: {Kind} {Name} spanning {XmlRange}",
+                                    msbuildObject.GetType().Name,
+                                    msbuildObject.Kind,
+                                    msbuildObject.Name,
+                                    msbuildObject.XmlRange
+                                );
+                            }
+                        }
+                        else
+                            Log.Verbose("MSBuild project not loaded; will used cached project state (as long as positional lookups are not required).");
+                    }
+                    else
+                        Log.Verbose("MSBuild project not loaded.");
+
+                    break;
+                }
+                case SolutionDocument solutionDocument:
+                {
+                    if (solutionDocument.HasSolution)
+                    {
+                        if (!solutionDocument.IsSolutionCached)
+                        {
+                            VsSolutionObject[] solutionObjects = solutionDocument.SolutionObjects.ToArray();
+                            Log.Verbose("Solution loaded ({SolutionObjectCount} solution objects).", solutionObjects.Length);
+
+                            foreach (VsSolutionObject solutionObject in solutionObjects)
+                            {
+                                Log.Verbose("{Type:l}: {Kind} {Name} spanning {XmlRange}",
+                                    solutionObject.GetType().Name,
+                                    solutionObject.Kind,
+                                    solutionObject.Name,
+                                    solutionObject.XmlRange
+                                );
+                            }
+                        }
+                        else
+                            Log.Verbose("Solution not loaded; will used cached project state (as long as positional lookups are not required).");
+                    }
+                    else
+                        Log.Verbose("Solution not loaded.");
+
+                    break;
+                }
+            }
         }
 
         /// <summary>

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -209,7 +209,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                 {
                     if (!solutionDocument.HasXml)
                     {
-                        Log.Warning("Failed to load solution file {ProjectFilePath}.", solutionDocument.SolutionFile.FullName);
+                        Log.Warning("Failed to load solution file {SolutionFilePath}.", solutionDocument.SolutionFile.FullName);
                         
                         Server.ClearBusy($"Failed to load solution file {solutionDocument.SolutionFile.FullName}.");
 

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -417,7 +417,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                             }
                         }
                         else
-                            Log.Verbose("MSBuild project not loaded; will used cached project state (as long as positional lookups are not required).");
+                            Log.Verbose("MSBuild project not loaded; will use cached project state (as long as positional lookups are not required).");
                     }
                     else
                         Log.Verbose("MSBuild project not loaded.");

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -303,7 +303,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                         return;
                     }
 
-                    Log.Information("Successfully reloaded project {ProjectFilePath}.", solutionDocument.SolutionFile.FullName);
+                    Log.Information("Successfully reloaded solution file {SolutionFilePath}.", solutionDocument.SolutionFile.FullName);
 
                     break;
                 }

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -444,7 +444,7 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
                             }
                         }
                         else
-                            Log.Verbose("Solution not loaded; will used cached project state (as long as positional lookups are not required).");
+                            Log.Verbose("Solution not loaded; will use cached solution state (as long as positional lookups are not required).");
                     }
                     else
                         Log.Verbose("Solution not loaded.");

--- a/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
+++ b/src/LanguageServer.Engine/Handlers/DocumentSyncHandler.cs
@@ -125,9 +125,19 @@ namespace MSBuildProjectTools.LanguageServer.Handlers
         {
             Server.NotifyBusy("Loading...");
 
-            Document document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
-            Workspace.PublishDiagnostics(document);
+            Document document;
+            try
+            {
+                document = await Workspace.GetDocument(parameters.TextDocument.Uri, cancellationToken: cancellationToken);
+            }
+            catch (Exception loadError)
+            {
+                Log.Error(loadError, "Failed to load document {DocumentUri}.", parameters.TextDocument.Uri);
+                Server.ClearBusy("Failed to load document.");
+                return;
+            }
 
+            Workspace.PublishDiagnostics(document);
             switch (document)
             {
                 case ProjectDocument projectDocument:

--- a/src/LanguageServer.Engine/LanguageServer.Engine.csproj
+++ b/src/LanguageServer.Engine/LanguageServer.Engine.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="GuiLabs.Language.Xml" />
     <PackageReference Include="Nito.AsyncEx.Tasks" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Logging" />

--- a/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
+++ b/src/LanguageServer.SemanticModel.MSBuild/LanguageServer.SemanticModel.MSBuild.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Nito.AsyncEx.Tasks" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Superpower" />
@@ -23,8 +24,8 @@
   <ItemGroup>
     <!-- Copy `help` folder from solution root to output and publish directories -->
     <Content Include="..\..\help\**" LinkBase="help">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 </Project>

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Nito.AsyncEx.Tasks" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Enrichers.Demystifier" />

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Serilog.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reactive.Disposables;
@@ -15,7 +17,6 @@ using Xunit.Abstractions;
 namespace MSBuildProjectTools.LanguageServer.IntegrationTests
 {
     using CustomProtocol;
-    using Newtonsoft.Json.Converters;
     using Utilities;
 
     public class BasicIntegrationTests(ITestOutputHelper testOutput) : IntegrationTestBase(testOutput), IAsyncLifetime
@@ -67,6 +68,64 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             Assert.NotNull(_fixture.Client!.ServerSettings?.Capabilities?.CompletionProvider);
             Assert.DoesNotContain(_fixture.Client!.RegistrationManager?.CurrentRegistrations,
                 reg => reg.Method == TextDocumentNames.Completion);
+        }
+
+        [Fact]
+        public async Task DocumentSyncCsproj()
+        {
+            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>  
+            </Project>
+            """);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            var busyNotificationBuffer = new ConcurrentQueue<BusyNotificationParams>();
+            using var receivedNotification = new ManualResetEventSlim(initialState: false);
+
+            using IDisposable notificationHandlerRegistration = _fixture.Client.Register(registry =>
+            {
+                registry.OnNotification<BusyNotificationParams>("msbuild/busy", notification =>
+                {
+                    busyNotificationBuffer.Enqueue(notification);
+                    receivedNotification.Set();
+                });
+            });
+
+            await _fixture.Client.SendRequest(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                },
+            }, timeout.Token);
+
+
+            receivedNotification.Wait(timeout.Token);
+
+            BusyNotificationParams[] actualBusyNotifications = busyNotificationBuffer.ToArray();
+            Log.Information("Actual busy-notifications: {NotificationJson:l}",
+                JsonConvert.SerializeObject(actualBusyNotifications, DumpSerializerSettings)
+            );
+
+            Assert.Collection(actualBusyNotifications,
+                notification1 =>
+                {
+                    Assert.True(notification1.IsBusy);
+                    Assert.Equal("Loading...", notification1.Message);
+                },
+                notification2 =>
+                {
+                    Assert.False(notification2.IsBusy);
+                    Assert.Equal("Project loaded.", notification2.Message);
+                }
+            );
         }
 
         [Fact]
@@ -354,6 +413,61 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                         ),
                         symbol03.Location.Range.ToNative()
                     );
+                }
+            );
+        }
+
+        [Fact]
+        public async Task DocumentSyncSlnx()
+        {
+            var testFilePath = Path.Combine(_workspaceRoot, "Test.slnx");
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Solution>
+
+            </Solution>
+            """);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            var busyNotificationBuffer = new ConcurrentQueue<BusyNotificationParams>();
+            using var receivedNotification = new ManualResetEventSlim(false);
+
+            using IDisposable notificationHandlerRegistration = _fixture.Client.Register(registry =>
+            {
+                registry.OnNotification<BusyNotificationParams>("msbuild/busy", notification =>
+                {
+                    busyNotificationBuffer.Enqueue(notification);
+                    receivedNotification.Set();
+                });
+            });
+
+            await _fixture.Client.SendRequest(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath),
+                },
+            }, timeout.Token);
+
+
+            receivedNotification.Wait();
+
+            BusyNotificationParams[] actualBusyNotifications = busyNotificationBuffer.ToArray();
+            Log.Information("Actual busy-notifications: {NotificationJson:l}",
+                JsonConvert.SerializeObject(actualBusyNotifications, DumpSerializerSettings)
+            );
+
+            Assert.Collection(actualBusyNotifications,
+                notification1 =>
+                {
+                    Assert.True(notification1.IsBusy);
+                    Assert.Equal("Loading...", notification1.Message);
+                },
+                notification2 =>
+                {
+                    Assert.False(notification2.IsBusy);
+                    Assert.Equal("Solution loaded.", notification2.Message);
                 }
             );
         }

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -30,6 +30,22 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             Formatting = Formatting.Indented,
         };
 
+        const string CsprojFileContent =
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>  
+            </Project>
+            """;
+        const string SlnxFileContent =
+            """
+            <Solution>
+
+            </Solution>
+            """;
+
         private readonly LanguageServerFixture _fixture = new(false);
         private readonly TempDirectory _workspaceRoot = new();
 
@@ -73,59 +89,9 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
         [Fact]
         public async Task DocumentSyncCsproj()
         {
-            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
-            await File.WriteAllTextAsync(testFilePath,
-            """
-            <Project Sdk="Microsoft.NET.Sdk">
-                <PropertyGroup>
-                    <OutputType>Exe</OutputType>
-                    <TargetFramework>net6.0</TargetFramework>
-                </PropertyGroup>  
-            </Project>
-            """);
+            await OpenDocumentFile("Test.csproj", CsprojFileContent, "Project loaded.");
 
-            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-            var busyNotificationBuffer = new ConcurrentQueue<BusyNotificationParams>();
-            using var receivedNotification = new ManualResetEventSlim(initialState: false);
-
-            using IDisposable notificationHandlerRegistration = _fixture.Client.Register(registry =>
-            {
-                registry.OnNotification<BusyNotificationParams>("msbuild/busy", notification =>
-                {
-                    busyNotificationBuffer.Enqueue(notification);
-                    receivedNotification.Set();
-                });
-            });
-
-            await _fixture.Client.SendRequest(new DidOpenTextDocumentParams
-            {
-                TextDocument = new TextDocumentItem
-                {
-                    Uri = DocumentUri.FromFileSystemPath(testFilePath),
-                },
-            }, timeout.Token);
-
-
-            receivedNotification.Wait(timeout.Token);
-
-            BusyNotificationParams[] actualBusyNotifications = busyNotificationBuffer.ToArray();
-            Log.Information("Actual busy-notifications: {NotificationJson:l}",
-                JsonConvert.SerializeObject(actualBusyNotifications, DumpSerializerSettings)
-            );
-
-            Assert.Collection(actualBusyNotifications,
-                notification1 =>
-                {
-                    Assert.True(notification1.IsBusy);
-                    Assert.Equal("Loading...", notification1.Message);
-                },
-                notification2 =>
-                {
-                    Assert.False(notification2.IsBusy);
-                    Assert.Equal("Project loaded.", notification2.Message);
-                }
-            );
+            //TODO: Do more checks related to "document sync"
         }
 
         [Fact]
@@ -420,56 +386,9 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
         [Fact]
         public async Task DocumentSyncSlnx()
         {
-            var testFilePath = Path.Combine(_workspaceRoot, "Test.slnx");
-            await File.WriteAllTextAsync(testFilePath,
-            """
-            <Solution>
+            await OpenDocumentFile("Test.slnx", SlnxFileContent, "Solution loaded.");
 
-            </Solution>
-            """);
-
-            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-            var busyNotificationBuffer = new ConcurrentQueue<BusyNotificationParams>();
-            using var receivedNotification = new ManualResetEventSlim(false);
-
-            using IDisposable notificationHandlerRegistration = _fixture.Client.Register(registry =>
-            {
-                registry.OnNotification<BusyNotificationParams>("msbuild/busy", notification =>
-                {
-                    busyNotificationBuffer.Enqueue(notification);
-                    receivedNotification.Set();
-                });
-            });
-
-            await _fixture.Client.SendRequest(new DidOpenTextDocumentParams
-            {
-                TextDocument = new TextDocumentItem
-                {
-                    Uri = DocumentUri.FromFileSystemPath(testFilePath),
-                },
-            }, timeout.Token);
-
-
-            receivedNotification.Wait();
-
-            BusyNotificationParams[] actualBusyNotifications = busyNotificationBuffer.ToArray();
-            Log.Information("Actual busy-notifications: {NotificationJson:l}",
-                JsonConvert.SerializeObject(actualBusyNotifications, DumpSerializerSettings)
-            );
-
-            Assert.Collection(actualBusyNotifications,
-                notification1 =>
-                {
-                    Assert.True(notification1.IsBusy);
-                    Assert.Equal("Loading...", notification1.Message);
-                },
-                notification2 =>
-                {
-                    Assert.False(notification2.IsBusy);
-                    Assert.Equal("Solution loaded.", notification2.Message);
-                }
-            );
+            //TODO: Do more checks related to "document sync"
         }
 
         [Fact]
@@ -579,24 +498,19 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
         /// <summary>
         ///     Test that the language server does process textDocument/didOpen
         ///     notification by testing that the busy state notification (msbuild/busy)
-        ///     reaches the client.
+        ///     reaches the client twice.
         /// </summary>
-        [Fact]
-        public async Task OpenCsproj()
+        [Theory]
+        [InlineData("Test.csproj", CsprojFileContent, "Project loaded.")]
+        [InlineData("Test.slnx", SlnxFileContent, "Solution loaded.")]
+        public async Task OpenDocumentFile(string fileName, string fileContent, string expectedNotBusyMsg)
         {
-            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
-            await File.WriteAllTextAsync(testFilePath,
-            """
-            <Project Sdk="Microsoft.NET.Sdk">
-                <PropertyGroup>
-                    <OutputType>Exe</OutputType>
-                    <TargetFramework>net6.0</TargetFramework>
-                </PropertyGroup>  
-            </Project>
-            """);
+            var testFilePath = Path.Combine(_workspaceRoot, fileName);
+            await File.WriteAllTextAsync(testFilePath, fileContent);
 
             IDisposable handlerRegistration = null;
             var tcsBusy = new TaskCompletionSource();
+            BusyNotificationParams firstBusyRaised = null;
 
             Action<Action<BusyNotificationParams>> attach =
                 handler =>
@@ -604,9 +518,13 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     var assertHandler = handler;
                     handler = @params =>
                     {
-                        assertHandler(@params);
-                        if (!@params.IsBusy)
+                        if (firstBusyRaised is null)
+                            firstBusyRaised = @params;
+                        else
+                        {
+                            assertHandler(@params);
                             tcsBusy.TrySetResult();
+                        }
                     };
                     var cancelReg = tcsBusy.CancelAfter(TimeSpan.FromSeconds(5));
                     var handlerReg = _fixture.Client.Register(
@@ -618,7 +536,7 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
             Action<Action<BusyNotificationParams>> detach =
                 handler => handlerRegistration?.Dispose();
 
-            var raisedBusy = await Assert.RaisesAsync(
+            var lastBusyRaised = (await Assert.RaisesAsync(
                 attach, detach,
                 () =>
                 {
@@ -632,10 +550,17 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     });
                     return tcsBusy.Task;
                 }
+            )).Arguments;
+
+            Log.Information("Actual busy-notifications: {NotificationJson:l}",
+                JsonConvert.SerializeObject(new[] { firstBusyRaised, lastBusyRaised }, DumpSerializerSettings)
             );
 
-            Assert.False(raisedBusy.Arguments.IsBusy);
-            Assert.Equal("Project loaded.", raisedBusy.Arguments.Message);
+            Assert.True(firstBusyRaised.IsBusy);
+            Assert.Equal("Loading...", firstBusyRaised.Message);
+
+            Assert.False(lastBusyRaised.IsBusy);
+            Assert.Equal(expectedNotBusyMsg, lastBusyRaised.Message);
         }
     }
 }

--- a/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
+++ b/test/LanguageServer.IntegrationTests/BasicIntegrationTests.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using NuGet.Versioning;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -142,6 +143,90 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                     "<Target>",
                 ],
                 actual: completionItems.Select(item => item.Label)
+            );
+        }
+
+        [Fact]
+        public async Task AutoCompletePackageReference()
+        {
+            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="Microsoft.Build" Version="" />
+                </ItemGroup>
+            </Project>
+            """);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            CompletionList completionList = await _fixture.Client.SendRequest(new CompletionParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath)
+                },
+                Position = new(6, 61)
+            }, timeout.Token);
+
+            Assert.NotNull(completionList);
+            Assert.NotNull(completionList.Items);
+
+            CompletionItem[] completionItems = completionList.Items.OrderBy(item => item.SortText ?? item.Label).ToArray();
+
+            Log.Information("Received {CompletionCount} completions from the language server.", completionItems.Length);
+            for (int itemIndex = 0; itemIndex < completionItems.Length; itemIndex++)
+            {
+                Log.Information("\tCompletionItems[{ItemIndex}] = {@CompletionItem}",
+                    itemIndex,
+                    completionItems[itemIndex]
+                );
+            }
+
+            Assert.NotEmpty(completionItems);
+            Assert.All(completionItems, item =>
+            {
+                Assert.Equal("Package Version", item.Detail);
+                Assert.True(SemanticVersion.TryParse(item.Label, out var actualSemVer), "item.Label can convert to semver");
+            });
+        }
+
+        [Fact]
+        public async Task HoverPackageReference()
+        {
+            var testFilePath = Path.Combine(_workspaceRoot, "Test.csproj");
+            await File.WriteAllTextAsync(testFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>  
+                <ItemGroup>
+                    <PackageReference Include="Microsoft.Build" Version="17.11.48" />
+                </ItemGroup>
+            </Project>
+            """);
+
+            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Hover hoverResult = await _fixture.Client.SendRequest(new HoverParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = DocumentUri.FromFileSystemPath(testFilePath)
+                },
+                Position = new Position(7, 10).ToLsp()
+            }, timeout.Token);
+
+            Assert.NotNull(hoverResult);
+            Assert.NotNull(hoverResult.Contents);
+            Assert.Equal(
+                "NuGet Package: Microsoft.Build Requested Version: `17.11.48` State: Not restored",
+                hoverResult.Contents.ToString()
             );
         }
 

--- a/test/LanguageServer.IntegrationTests/IntegrationTestBase.cs
+++ b/test/LanguageServer.IntegrationTests/IntegrationTestBase.cs
@@ -24,7 +24,8 @@ namespace MSBuildProjectTools.LanguageServer.IntegrationTests
                 .Enrich.With<LoggingModule.SourceComponentLogEnricher>()
                 .Enrich.With<ComputedLogLevelPrefixEnricher>()
                 .WriteTo.TestOutput(TestOutput, outputTemplate: "{ComputedLogLevelPrefix:l}{Message:lj}{NewLine}{Exception}")
-                .CreateLogger();
+                .CreateLogger()
+                .ForContext(GetType());
         }
 
         protected ITestOutputHelper TestOutput { get; }


### PR DESCRIPTION
Also, add integration tests for notifications from `OnDidLoadDocument` (.csproj and .slnx)

tintoy/msbuild-project-tools-server#138